### PR TITLE
use com.iab.gdpr_android rather than com.iab.gdpr Consent String SDK

### DIFF
--- a/cmplibrary/build.gradle
+++ b/cmplibrary/build.gradle
@@ -5,7 +5,6 @@ plugins {
 def VERSION_NAME = "2.0.1"
 
 apply plugin: 'com.android.library'
-//apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.bintray'
 version VERSION_NAME
@@ -46,8 +45,13 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     api 'com.google.guava:guava:27.0.1-android'
-    implementation 'com.conversantmedia.gdpr:consent-string-sdk-java:3.0.2'
     implementation 'com.loopj.android:android-async-http:1.4.9'
+
+    // Unfortunately consent-string-sdk-java only supports Java 8 and above. That means API > 26
+    // The following is a port to android environment
+    // for more information check https://github.com/InteractiveAdvertisingBureau/Consent-String-SDK-Java/issues/21
+    compile 'com.iab.gdpr_android:gdpr_android:1.0.1'
+//    implementation 'com.conversantmedia.gdpr:consent-string-sdk-java:3.0.2'
 }
 
 task sourcesJar(type: Jar) {

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLib.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLib.java
@@ -23,8 +23,8 @@ import android.view.View;
 
 import java.util.HashSet;
 
-import com.iab.gdpr.consent.VendorConsent;
-import com.iab.gdpr.consent.VendorConsentDecoder;
+import com.iab.gdpr_android.consent.VendorConsent;
+import com.iab.gdpr_android.consent.VendorConsentDecoder;
 
 /**
  * Entry point class encapsulating the Consents a giving user has given to one or several vendors.

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SourcePointClientBuilder.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SourcePointClientBuilder.java
@@ -10,8 +10,8 @@ class SourcePointClientBuilder {
     private static final String DEFAULT_INTERNAL_CMP_URL = "https://cmp.sp-stage.net";
     private static final String DEFAULT_CMP_URL = "https://sourcepoint.mgr.consensu.org";
 
-    private static final String DEFAULT_INTERNAL_IN_APP_MESSAGING_PAGE_URL = "http://in-app-messaging.pm.cmp.sp-stage.net/";
-    private static final String DEFAULT_IN_APP_MESSAGING_PAGE_URL = "http://in-app-messaging.pm.sourcepoint.mgr.consensu.org/";
+    private static final String DEFAULT_INTERNAL_IN_APP_MESSAGING_PAGE_URL = "https://in-app-messaging.pm.cmp.sp-stage.net/";
+    private static final String DEFAULT_IN_APP_MESSAGING_PAGE_URL = "https://in-app-messaging.pm.sourcepoint.mgr.consensu.org/";
 
     private EncodedParam site, accountId;
     private boolean staging, stagingCampaign;


### PR DESCRIPTION
[The IAB Consent SDK only supports Java 8 and above](https://github.com/InteractiveAdvertisingBureau/Consent-String-SDK-Java/issues/21). 
[There's a port of it to Android](https://github.com/didomi/Consent-String-SDK-Android)

In this PR we change from the former SDK to the latter. 