### PR TITLE
Render `webview` if `viewGroup` is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.0 (March 25, 2019)
+* We changed the way the `WebView` is loaded. You know have two options: 
+  1. If you don't mind us managing the view for you, make sure to call `setViewGroup` passing the `ViewGroup` in which the `WebView` should be attached to and we'll take care of everything for you.
+  2. If you need more control over views, simply don't call `setViewGroup`. You'll need to add/remove `ConsentLib#webView` to/from your view hierarchy by yourself. This will usually be done on `willShowMessage` and `onInteractionComplete`.   
+
 ## 2.1.1 (March 20, 2019)
 * Implemented the callback method `willShowMessage`
 * Re-throw an exception as `ConsentLibException` happening when the consent string could not be parsed

--- a/app/src/main/java/com/example/dmitrirabinowitz/test_project/MainActivity.java
+++ b/app/src/main/java/com/example/dmitrirabinowitz/test_project/MainActivity.java
@@ -1,13 +1,12 @@
 package com.example.dmitrirabinowitz.test_project;
 
-import android.app.Activity;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.Button;
+import android.view.ViewGroup;
 
 import com.sourcepoint.cmplibrary.ConsentLib;
 import com.sourcepoint.cmplibrary.CustomVendorConsent;
@@ -21,123 +20,106 @@ public class MainActivity extends AppCompatActivity {
 
     private SharedPreferences sharedPref;
 
-    private ConsentLib buildConsentLib(Activity activity, Boolean showPM) throws ConsentLibException {
-        return ConsentLib.newBuilder(22, "mobile.demo", activity)
-                // optional, used for running stage campaigns
-                .setStage(false)
-                // optional, set custom targeting parameters value can be String and Integer
-                .setTargetingParam("CMP", showPM.toString())
-                .setWillShowMessage(new ConsentLib.Callback() {
-                    @Override
-                    public void run(ConsentLib _c) {
-                        Log.i(TAG, "The message is about to be shown.");
-                    }
-                })
-                // type will be available as Integer at cLib.choiceType
-                .setOnMessageChoiceSelect(new ConsentLib.Callback() {
-                    @Override
-                    public void run(ConsentLib c) {
-                        Log.i(TAG, "Choice type selected by user: " + c.choiceType.toString());
-                    }
-                })
-                // optional, callback triggered when consent data is captured when called
-                .setOnInteractionComplete(new ConsentLib.Callback() {
-                    @Override
-                    public void run(ConsentLib c) {
-                        Log.i(TAG, "euconsent prop: " + c.euconsent);
-                        Log.i(TAG, "consentUUID prop: " + c.consentUUID);
-                        Log.i(TAG, "euconsent in shared preferences: " + sharedPref.getString(ConsentLib.EU_CONSENT_KEY, null));
-                        Log.i(TAG, "consentUUID in shared preferences: " + sharedPref.getString(ConsentLib.CONSENT_UUID_KEY, null));
-                        Log.i(TAG, "IABConsent_SubjectToGDPR in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_SUBJECT_TO_GDPR, null));
-                        Log.i(TAG, "IABConsent_ConsentString in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_CONSENT_STRING, null));
-                        Log.i(TAG, "IABConsent_ParsedPurposeConsents in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_PARSED_PURPOSE_CONSENTS, null));
-                        Log.i(TAG, "IABConsent_ParsedVendorConsents in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_PARSED_VENDOR_CONSENTS, null));
+    private void buildAndRunConsentLib(Boolean showPM) {
+        try {
+            ConsentLib.newBuilder(22, "mobile.demo", this)
+                    .setStage(false) // optional, used for running stage campaigns
+                    .setViewGroup(findViewById(android.R.id.content))
+                    // optional, set custom targeting parameters value can be String and Integer
+                    .setTargetingParam("CMP", showPM.toString())
+                    .setWillShowMessage(new ConsentLib.Callback() {
+                        @Override
+                        public void run(ConsentLib _c) {
+                            Log.i(TAG, "The message is about to be shown.");
+                        }
+                    })
+                    .setOnInteractionComplete(new ConsentLib.Callback() {
+                        @Override
+                        public void run(ConsentLib c) {
+                            Log.i(TAG, "euconsent in shared preferences: " + sharedPref.getString(ConsentLib.EU_CONSENT_KEY, null));
+                            Log.i(TAG, "consentUUID in shared preferences: " + sharedPref.getString(ConsentLib.CONSENT_UUID_KEY, null));
+                            Log.i(TAG, "IABConsent_SubjectToGDPR in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_SUBJECT_TO_GDPR, null));
+                            Log.i(TAG, "IABConsent_ConsentString in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_CONSENT_STRING, null));
+                            Log.i(TAG, "IABConsent_ParsedPurposeConsents in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_PARSED_PURPOSE_CONSENTS, null));
+                            Log.i(TAG, "IABConsent_ParsedVendorConsents in shared preferences: " + sharedPref.getString(ConsentLib.IAB_CONSENT_PARSED_VENDOR_CONSENTS, null));
 
-                        try {
-                            // Get the consents for a collection of non-IAB vendors
-                            c.getCustomVendorConsents(
-                                    new String[]{"5bf7f5c5461e09743fe190b3", "5b2adb86173375159f804c77"},
-                                    new ConsentLib.OnLoadComplete() {
-                                        @Override
-                                        public void onSuccess(Object result) {
-                                            HashSet<CustomVendorConsent> consents = (HashSet) result;
-                                            for (CustomVendorConsent consent : consents) {
-                                                if (consent.id.equals("5bf7f5c5461e09743fe190b3")) {
-                                                    Log.i(TAG, "Consented to non-IAB vendor 1: "+consent.name);
-                                                }
-                                                if (consent.id.equals("5b2adb86173375159f804c77")) {
-                                                    Log.i(TAG, "Consented to non-IAB vendor 2: "+consent.name);
+                            try {
+                                // Get the consents for a collection of non-IAB vendors
+                                c.getCustomVendorConsents(
+                                        new String[]{"5bf7f5c5461e09743fe190b3", "5b2adb86173375159f804c77"},
+                                        new ConsentLib.OnLoadComplete() {
+                                            @Override
+                                            public void onSuccess(Object result) {
+                                                HashSet<CustomVendorConsent> consents = (HashSet) result;
+                                                for (CustomVendorConsent consent : consents) {
+                                                    if (consent.id.equals("5bf7f5c5461e09743fe190b3")) {
+                                                        Log.i(TAG, "Consented to non-IAB vendor 1: " + consent.name);
+                                                    }
+                                                    if (consent.id.equals("5b2adb86173375159f804c77")) {
+                                                        Log.i(TAG, "Consented to non-IAB vendor 2: " + consent.name);
+                                                    }
                                                 }
                                             }
-                                        }
-                                        @Override
-                                        public void onFailure(ConsentLibException exception) {
-                                            Log.d(TAG, "Something went wrong :( " + exception);
-                                        }
-                                    });
 
-                            // Example usage of getting all purpose consent results
-                            c.getCustomPurposeConsents(new ConsentLib.OnLoadComplete() {
-                                public void onSuccess(Object result) {
-                                    HashSet<CustomPurposeConsent> consents = (HashSet) result;
-                                    for (CustomPurposeConsent consent : consents) {
-                                        Log.i(TAG, "Consented to purpose: " + consent.name);
+                                            @Override
+                                            public void onFailure(ConsentLibException exception) {
+                                                Log.d(TAG, "Something went wrong :( " + exception);
+                                            }
+                                        });
+
+                                // Example usage of getting all purpose consent results
+                                c.getCustomPurposeConsents(new ConsentLib.OnLoadComplete() {
+                                    public void onSuccess(Object result) {
+                                        HashSet<CustomPurposeConsent> consents = (HashSet) result;
+                                        for (CustomPurposeConsent consent : consents) {
+                                            Log.i(TAG, "Consented to purpose: " + consent.name);
+                                        }
                                     }
-                                }
-                            });
+                                });
 
-                            // Example usage of getting IAB vendor consent results for a list of vendors
-                            boolean[] IABVendorConsents = c.getIABVendorConsents(new int[]{81, 82});
-                            Log.i(TAG, String.format("Consented to IAB vendors: 81 -> %b, 82 -> %b",
-                                IABVendorConsents[0],
-                                IABVendorConsents[1]
-                            ));
+                                // Example usage of getting IAB vendor consent results for a list of vendors
+                                boolean[] IABVendorConsents = c.getIABVendorConsents(new int[]{81, 82});
+                                Log.i(TAG, String.format("Consented to IAB vendors: 81 -> %b, 82 -> %b",
+                                        IABVendorConsents[0],
+                                        IABVendorConsents[1]
+                                ));
 
-                            // Example usage of getting IAB purpose consent results for a list of purposes
-                            boolean[] IABPurposeConsents = c.getIABPurposeConsents(new int[]{2, 3});
-                            Log.i(TAG, String.format("Consented to IAB purposes: 2 -> %b, 3 -> %b",
-                                IABPurposeConsents[0],
-                                IABPurposeConsents[1]
-                            ));
+                                // Example usage of getting IAB purpose consent results for a list of purposes
+                                boolean[] IABPurposeConsents = c.getIABPurposeConsents(new int[]{2, 3});
+                                Log.i(TAG, String.format("Consented to IAB purposes: 2 -> %b, 3 -> %b",
+                                        IABPurposeConsents[0],
+                                        IABPurposeConsents[1]
+                                ));
 
-                        } catch (ConsentLibException e) {
-                            e.printStackTrace();
+                            } catch (ConsentLibException e) {
+                                e.printStackTrace();
+                            }
                         }
-                    }
-                })
-                .setOnErrorOccurred(new ConsentLib.Callback() {
-                    @Override
-                    public void run(ConsentLib c) {
-                        Log.d(TAG, "Something went wrong: ", c.error);
-                    }
-                })
-                // generate ConsentLib at this point modifying builder will not do anything
-                .build();
+                    })
+                    .setOnErrorOccurred(new ConsentLib.Callback() {
+                        @Override
+                        public void run(ConsentLib c) {
+                            Log.d(TAG, "Something went wrong: ", c.error);
+                        }
+                    })
+                    // generate ConsentLib at this point modifying builder will not do anything
+                    .build()
+                    .run();
+        } catch (Exception exception) {
+            exception.printStackTrace();
+        }
     }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        final Button button = findViewById(R.id.review_consents);
         sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
-        final Activity activity = this;
 
-        try {
-            // build the consent lib and run it on app start
-            buildConsentLib(activity, false).run();
+        findViewById(R.id.review_consents).setOnClickListener(new View.OnClickListener() {
+            public void onClick(View _v) { buildAndRunConsentLib(true); }
+        });
 
-            button.setOnClickListener(new View.OnClickListener() {
-                public void onClick(View _v) {
-                    try{
-                        // build the consent lib and run it on button click
-                        buildConsentLib(activity, true).run();
-                    }
-                    catch (Exception e) { e.printStackTrace(); }
-                }
-            });
-        } catch (ConsentLibException e) {
-            e.printStackTrace();
-        }
+        buildAndRunConsentLib(false);
     }
 }

--- a/app/src/main/java/com/example/dmitrirabinowitz/test_project/MainActivity.java
+++ b/app/src/main/java/com/example/dmitrirabinowitz/test_project/MainActivity.java
@@ -6,7 +6,6 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.view.ViewGroup;
 
 import com.sourcepoint.cmplibrary.ConsentLib;
 import com.sourcepoint.cmplibrary.CustomVendorConsent;

--- a/cmplibrary/build.gradle
+++ b/cmplibrary/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.jfrog.bintray" version "1.8.4"
 }
 
-def VERSION_NAME = "2.1.1"
+def VERSION_NAME = "2.2.0"
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 26
-        versionCode 21
+        versionCode 22
         versionName VERSION_NAME
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLibBuilder.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLibBuilder.java
@@ -2,7 +2,6 @@ package com.sourcepoint.cmplibrary;
 
 import android.app.Activity;
 import android.os.Build;
-import android.view.View;
 import android.view.ViewGroup;
 
 import org.json.JSONException;
@@ -191,18 +190,6 @@ public class ConsentLibBuilder {
         targetingParamsString = new EncodedParam("targetingParams", targetingParams.toString());
     }
 
-    private void setDefaults () throws ConsentLibException.BuildException {
-        if (viewGroup == null) {
-            // render on top level activity view if no viewGroup specified
-            View view = activity.getWindow().getDecorView().findViewById(android.R.id.content);
-            if (view instanceof ViewGroup) {
-                viewGroup = (ViewGroup) view;
-            } else {
-                throw new ConsentLibException.BuildException("Current window is not a ViewGroup, can't render WebView");
-            }
-        }
-    }
-
     /**
      * The Android 4.x Browser throws an exception when parsing SourcePoint's javascript.
      * @return true if the API level is not supported
@@ -228,7 +215,6 @@ public class ConsentLibBuilder {
         }
 
         try {
-            setDefaults();
             setTargetingParamsString();
         } catch (ConsentLibException e) {
             this.activity = null; // release reference to activity

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLibBuilder.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLibBuilder.java
@@ -20,7 +20,7 @@ public class ConsentLibBuilder {
     String mmsDomain, cmpDomain, msgDomain = null;
     String page = "";
     ViewGroup viewGroup = null;
-    ConsentLib.Callback onMessageChoiceSelect, onInteractionComplete, onErrorOccurred, willShowMessage = noOpCallback;
+    ConsentLib.Callback onMessageChoiceSelect, onInteractionComplete, onErrorOccurred, willShowMessage;
     boolean staging, stagingCampaign = false;
     EncodedParam targetingParamsString = null;
     ConsentLib.DebugLevel debugLevel = ConsentLib.DebugLevel.OFF;
@@ -29,6 +29,7 @@ public class ConsentLibBuilder {
         this.accountId = accountId;
         this.siteName = siteName;
         this.activity = activity;
+        onMessageChoiceSelect = onInteractionComplete = onErrorOccurred = willShowMessage = noOpCallback;
     }
 
     /**


### PR DESCRIPTION
TL;DR; If you want us to show and hide the Privacy Manager in your views, call the `setViewGroup` passing a view and we'll manage the rest. Otherwise, you'll have to add and remove the `ConsentLib#webView` when you see best fit.

Previously, if `viewGroup` was null we'd get the Activity's content screen and attach the `WebView` to it. In order to give more flexibility on how and when the `WebView` should be displayed, we only attach it to the `viewGroup` if one is given. Otherwise, it'll be up to the app to decide what to do with the `WebView`.