### PR TITLE
enable new PM

### DIFF
--- a/app/src/main/java/com/example/dmitrirabinowitz/test_project/MainActivity.java
+++ b/app/src/main/java/com/example/dmitrirabinowitz/test_project/MainActivity.java
@@ -25,7 +25,7 @@ public class MainActivity extends AppCompatActivity {
                 .setStage(false) // optional, used for running stage campaigns
                 .setViewGroup(findViewById(android.R.id.content))
                 // optional, set custom targeting parameters value can be String and Integer
-                .setTargetingParam("CMP", showPM.toString())
+                .setTargetingParam("MyPrivacyManager", showPM.toString())
                 //optional,  set message time out , default is 5 seconds
                 .setMessageTimeOut(15000)   
                 .setOnMessageReady(new ConsentLib.Callback() {

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLib.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLib.java
@@ -93,7 +93,7 @@ public class ConsentLib {
     private Callback onMessageReady;
     private final EncodedParam encodedTargetingParams;
     private final EncodedParam encodedDebugLevel;
-    private final boolean weOwnTheView;
+    private final boolean weOwnTheView, newPM;
 
     //default time out changes
     private boolean onMessageReadyCalled = false;
@@ -138,6 +138,7 @@ public class ConsentLib {
         encodedTargetingParams = b.targetingParamsString;
         encodedDebugLevel = new EncodedParam("debugLevel", b.debugLevel.name());
         viewGroup = b.viewGroup;
+        newPM = b.newPM;
 
         weOwnTheView = viewGroup != null;
         // configurable time out
@@ -220,7 +221,7 @@ public class ConsentLib {
     public void run() throws ConsentLibException.NoInternetConnectionException {
         onMessageReadyCalled = false;
         if(webView == null) { webView = buildWebView(); }
-        webView.loadMessage(sourcePoint.messageUrl(encodedTargetingParams, encodedDebugLevel));
+        webView.loadMessage(sourcePoint.messageUrl(encodedTargetingParams, encodedDebugLevel, newPM));
         mCountDownTimer = getTimer(defaultMessageTimeOut);
         mCountDownTimer.start();
         setSharedPreference(IAB_CONSENT_CMP_PRESENT, true);

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLibBuilder.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLibBuilder.java
@@ -17,11 +17,11 @@ public class ConsentLibBuilder {
     Activity activity;
     int accountId;
     String siteName;
-    String mmsDomain, cmpDomain, msgDomain = null;
+    String mmsDomain, cmpDomain, msgDomain;
     String page = "";
     ViewGroup viewGroup = null;
     ConsentLib.Callback onMessageChoiceSelect, onInteractionComplete, onErrorOccurred, onMessageReady;
-    boolean staging, stagingCampaign = false;
+    boolean staging, stagingCampaign, newPM;
     EncodedParam targetingParamsString = null;
     ConsentLib.DebugLevel debugLevel = ConsentLib.DebugLevel.OFF;
     long defaultMessageTimeOut = 5000;
@@ -30,6 +30,8 @@ public class ConsentLibBuilder {
         this.accountId = accountId;
         this.siteName = siteName;
         this.activity = activity;
+        mmsDomain = cmpDomain = msgDomain = null;
+        staging = stagingCampaign = newPM = false;
         onMessageChoiceSelect = onInteractionComplete = onErrorOccurred = onMessageReady = noOpCallback;
     }
 
@@ -97,7 +99,7 @@ public class ConsentLibBuilder {
 
     /**
      * Called when the Dialog message is about to be shown
-     * @param callback
+     * @param callback to be called when the message is ready to be displayed
      * @return ConsentLibBuilder
      */
     public ConsentLibBuilder setOnMessageReady(ConsentLib.Callback callback) {
@@ -107,7 +109,7 @@ public class ConsentLibBuilder {
 
     /**
      *  <b>Optional</b> Sets a Callback to be called when something goes wrong in the WebView
-     * @param callback
+     * @param callback called when something wrong happens in the webview
      * @return ConsentLibBuilder - the next build step
      * @see ConsentLibBuilder
      */
@@ -137,6 +139,11 @@ public class ConsentLibBuilder {
      */
     public ConsentLibBuilder setInternalStage(boolean st) {
         staging = st;
+        return this;
+    }
+
+    public ConsentLibBuilder enableNewPM(boolean newPM) {
+        this.newPM = newPM;
         return this;
     }
 

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SourcePointClient.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SourcePointClient.java
@@ -83,9 +83,10 @@ class SourcePointClient {
                 "&euconsent=" + euconsentParam;
     }
 
-    String messageUrl(EncodedParam targetingParams, EncodedParam debugLevel) {
+    String messageUrl(EncodedParam targetingParams, EncodedParam debugLevel, boolean newPM) {
         HashSet<String> params = new HashSet<>();
-        params.add("_sp_accountId=" + String.valueOf(accountId));
+        params.add("_sp_pmOrigin=" + (newPM ? "stage" : "production"));
+        params.add("_sp_accountId=" + accountId);
         params.add("_sp_cmp_inApp=true");
         params.add("_sp_writeFirstPartyCookies=true");
         params.add("_sp_siteHref=" + site);


### PR DESCRIPTION
With this PR we make possible for the user to switch between the "old" and "new" Privacy Manager, before it's completely rolled out.