### PR TITLE
changes made to resolve memeory leak issue

### DIFF
--- a/app/src/main/java/com/sourcepoint/test_project/ConsentLibInstance.java
+++ b/app/src/main/java/com/sourcepoint/test_project/ConsentLibInstance.java
@@ -1,0 +1,40 @@
+package com.sourcepoint.test_project;
+
+import android.app.Activity;
+import android.util.Log;
+
+import com.sourcepoint.cmplibrary.ConsentLib;
+import com.sourcepoint.cmplibrary.ConsentLibException;
+import com.sourcepoint.cmplibrary.CustomVendorConsent;
+
+import java.util.HashSet;
+
+/*Class to retrun singl;eton instance of consentLib*/
+public class ConsentLibInstance {
+
+    private static ConsentLib consentLib = null;
+
+    private ConsentLibInstance(Activity activity) throws ConsentLibException {
+        if (consentLib == null){
+            consentLib = ConsentLib.newBuilder(22, "mobile.demo", 2372,"5c0e81b7d74b3c30c6852301",activity)
+                    .setStage(true)
+                    .setViewGroup(activity.findViewById(android.R.id.content))
+                    .setShowPM(false)
+                    .setOnMessageReady(consentLib -> Log.i("ConsentLibInstance", "onMessageReady"))
+                    .setOnConsentReady(consentLib -> consentLib.getCustomVendorConsents(results -> {
+                        HashSet<CustomVendorConsent> consents = (HashSet) results;
+                        for(CustomVendorConsent consent : consents)
+                            Log.i("ConsentLibInstance", "Consented to: "+consent);
+                    }))
+                    .setOnErrorOccurred(c -> Log.i("ConsentLibInstance", "Something went wrong: ", c.error))
+                    .build();
+        }
+    }
+
+    public static ConsentLib getConsentLibInstance(Activity activity) throws ConsentLibException{
+        if (consentLib == null){
+            new ConsentLibInstance(activity);
+        }
+        return consentLib;
+    }
+}

--- a/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/test_project/MainActivity.java
@@ -13,10 +13,10 @@ import java.util.HashSet;
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = "MainActivity";
 
-    private ConsentLib consentLib;
+    private ConsentLib consentLib = null;
 
     private ConsentLib buildAndRunConsentLib(Boolean showPM) throws ConsentLibException {
-        return ConsentLib.newBuilder(22, "mobile.demo", 2372,"5c0e81b7d74b3c30c6852301",this)
+        /*return ConsentLib.newBuilder(22, "mobile.demo", 2372,"5c0e81b7d74b3c30c6852301",this)
                 .setStage(true)
                 .setViewGroup(findViewById(android.R.id.content))
                 .setShowPM(showPM)
@@ -27,14 +27,17 @@ public class MainActivity extends AppCompatActivity {
                         Log.i(TAG, "Consented to: "+consent);
                 }))
                 .setOnErrorOccurred(c -> Log.i(TAG, "Something went wrong: ", c.error))
-                .build();
+                .build();*/
+        return ConsentLibInstance.getConsentLibInstance(this);
     }
 
     @Override
     protected void onResume() {
         super.onResume();
         try {
-            consentLib = buildAndRunConsentLib(false);
+            if (consentLib == null){
+                consentLib = buildAndRunConsentLib(false);
+            }
             consentLib.run();
         } catch (ConsentLibException e) {
             e.printStackTrace();
@@ -45,14 +48,36 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        /*check if consentLib object is already present in bundle object if yes then reuse it*/
+        if (savedInstanceState != null && savedInstanceState.getSerializable("consentLib") != null){
+            consentLib = (ConsentLib) savedInstanceState.getSerializable("consentLib");
+        }
         findViewById(R.id.review_consents).setOnClickListener(_v -> {
             try {
-                consentLib = buildAndRunConsentLib(true);
+                if (consentLib == null){
+                    consentLib = buildAndRunConsentLib(false);
+                }
                 consentLib.run();
+
             } catch (ConsentLibException e) {
                 e.printStackTrace();
             }
         });
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        /*store consentLib object in bundle*/
+        outState.putSerializable("consentLib",consentLib);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        /*check if consentLib object is already present in bundle object if yes then reuse it*/
+        if (savedInstanceState.getSerializable("consentLib") != null)
+        consentLib =(ConsentLib)savedInstanceState.getSerializable("consentLib");
     }
 
     @Override

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLib.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/ConsentLib.java
@@ -10,6 +10,7 @@ import android.view.ViewGroup;
 import com.iab.gdpr_android.consent.VendorConsent;
 import com.iab.gdpr_android.consent.VendorConsentDecoder;
 
+import java.io.Serializable;
 import java.util.HashSet;
 
 /**
@@ -20,7 +21,7 @@ import java.util.HashSet;
  * }
  * </pre>
  */
-public class ConsentLib {
+public class ConsentLib implements Serializable { /*made this serializable to store in bundle object*/
     /**
      * If the user has consent data stored, reading for this key in the shared preferences will return true
      */
@@ -523,6 +524,7 @@ public class ConsentLib {
             }
             webView.destroy();
             webView = null;
+            activity = null;
         }
     }
 }


### PR DESCRIPTION
1. released activity reference in onDestroy method
2. created ConsentLibInstance class to return single instance of consentLib.
3. implemented onSaveInstanceState and onRetanInstanceState methods of activity to reuse consenLib object.
These changes restrict multiple object creation but application crashes on screen rotation.