### PR TITLE
[ON HOLD]Do not present view when loading pm from webview

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
@@ -198,7 +198,7 @@ public class GDPRConsentLib {
             @Override
             public void onConsentUIReady() {
                 cancelCounter();
-                runOnLiveActivityUIThread(() -> GDPRConsentLib.this.onConsentUIReady.run(this));
+                if(this.getParent() == null) showView(this);
             }
 
             @Override


### PR DESCRIPTION
This will make the consent lib only call onConsentUIReady if thw web view does not have a parent yet.
Even though this change useful to avoid app crashes, further discussion is needed to decide if this should be the SDK responsibility at all.