### PR TITLE
SP-3813 add property id to pm url (as site_id query param)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.2 (Jun, 02, 2020)
+* fix an issue when loading the PM for properties belonging to property groups - 7c098
+* fix an issue preventing campaign with targeting params from showing consent message - 5890c
+
 ## 5.2.1 (May, 20, 2020)
 * fix issue preventing release of 5.2.0
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following documentation and code is suitable for properties supporting TCFv2
 ```
 ...
 dependencies {
-    implementation 'com.sourcepoint.cmplibrary:cmplibrary:5.1.2'
+    implementation 'com.sourcepoint.cmplibrary:cmplibrary:5.2.2'
 }
 
 ```

--- a/cmplibrary/build.gradle
+++ b/cmplibrary/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "com.jfrog.bintray" version "1.8.4"
 }
 
-def VERSION_NAME = "5.2.1"
+def VERSION_NAME = "5.2.2"
 
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
@@ -492,6 +492,7 @@ public class GDPRConsentLib {
     String pmUrl() {
         HashSet<String> params = new HashSet<>();
         params.add("message_id=" + pmId);
+        params.add("site_id="+ propertyId);
         if (consentUUID != null) params.add("consentUUID=" + consentUUID);
 
         return PM_BASE_URL + "?" + TextUtils.join("&", params);

--- a/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLibTest.java
+++ b/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLibTest.java
@@ -13,6 +13,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -49,8 +50,8 @@ public class GDPRConsentLibTest {
     @Captor
     ArgumentCaptor<Runnable> lambdaCaptor;
 
-    private ConsentLibBuilder builderMock(){
-        return new ConsentLibBuilder(123, "example.com", 321, "abcd", activityMock){
+    private ConsentLibBuilder builderMock(int accountId, String propertyName, int propertyId, String pmId, Activity activity){
+        return new ConsentLibBuilder(accountId, propertyName, propertyId, pmId, activity){
             @Override
             public SourcePointClient getSourcePointClient(){
                 return sourcePointClientMock;
@@ -64,6 +65,10 @@ public class GDPRConsentLibTest {
                 return timerMock;
             }
         };
+    }
+
+    private ConsentLibBuilder builderMock(){
+        return builderMock(123, "example.com", 321, "abcd", activityMock);
     }
 
     private void setStoreClientMock(){
@@ -85,7 +90,6 @@ public class GDPRConsentLibTest {
         doReturn(timerMock).when(timerMock).start();
         doNothing().when(timerMock).cancel();
     }
-
 
     @Before
     public void setUp() {
@@ -171,5 +175,14 @@ public class GDPRConsentLibTest {
         verify(storeClientMock).setMetaData(lib.metaData);
         verify(storeClientMock).setTCData(lib.userConsent.TCData);
         verify(storeClientMock).setConsentString(lib.euConsent);
+    }
+
+    @Test
+    public void pmUrl() {
+        GDPRConsentLib lib = builderMock(1, "propertyName", 1, "pmId", activityMock).build();
+        lib.consentUUID = null;
+        assertEquals(lib.pmUrl(), "https://notice.sp-prod.net/privacy-manager/index.html?site_id=1&message_id=pmId");
+        lib.consentUUID = "ExampleUUID";
+        assertEquals(lib.pmUrl(), "https://notice.sp-prod.net/privacy-manager/index.html?consentUUID=ExampleUUID&site_id=1&message_id=pmId");
     }
 }


### PR DESCRIPTION
Without the `site_id` query param, the PM will work only for properties that don't belong to property groups. 
If the `site_id` query param is missing and the property is a grouped property, the PM will try to load the "default" PM from that group which is not always the correct one. 