### PR TITLE
make VendorGrant public

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRUserConsent.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRUserConsent.java
@@ -107,7 +107,7 @@ public class GDPRUserConsent {
             return json;
         }
 
-        class VendorGrant {
+        public class VendorGrant {
             public boolean vendorGrant;
             public HashMap<String, Boolean> purposeGrants;
             VendorGrant(JSONObject jVendorGrant) throws ConsentLibException {


### PR DESCRIPTION
If the `VendorGrant` class is not public we can't access its values like:

```java
VendorGrant vendorGrant = consent.vendorGrants.get("5e4a5fbf26de4a77922b38a6");
if (vendorGrant != null && vendorGrant.vendorGrant) {
    // vendor is granted
} else {
    // vendor is not granted
}
```