### PR TITLE
SP-4544 avoid logging js errors

### DIFF
--- a/app/src/main/java/com/sourcepoint/example_app/MainActivity.java
+++ b/app/src/main/java/com/sourcepoint/example_app/MainActivity.java
@@ -78,13 +78,13 @@ public class MainActivity extends AppCompatActivity {
                 })
                 .setOnError(error -> {
                     Log.e(TAG, "Something went wrong: ", error);
-                    Log.i(TAG, "ConsentLibErrorMessage: " + error.consentLibErrorMessage);
+                    Log.e(TAG, "ConsentLibErrorMessage: " + error.consentLibErrorMessage);
                 })
-                .setOnPMReady(()-> Log.e(TAG, "PM Ready"))
-                .setOnMessageReady(()-> Log.e(TAG, "Message Ready"))
-                .setOnPMFinished(()-> Log.e(TAG, "PM Finished"))
-                .setOnMessageFinished(()-> Log.e(TAG, "Message Finished"))
-                .setOnAction(actionType  -> Log.e(TAG , "ActionType : "+actionType.toString()))
+                .setOnPMReady(()-> Log.i(TAG, "PM Ready"))
+                .setOnMessageReady(()-> Log.i(TAG, "Message Ready"))
+                .setOnPMFinished(()-> Log.i(TAG, "PM Finished"))
+                .setOnMessageFinished(()-> Log.i(TAG, "Message Finished"))
+                .setOnAction(actionType  -> Log.i(TAG , "ActionType : "+actionType.toString()))
                 .build();
     }
 

--- a/cmplibrary/src/main/res/raw/js_receiver.js
+++ b/cmplibrary/src/main/res/raw/js_receiver.js
@@ -1,50 +1,74 @@
-window.addEventListener('message', handleEvent);
-function handleEvent(event) {
-    try {
-        JSReceiver.log(JSON.stringify(event.data, null, 2));
-        if (event.data.name === 'sp.showMessage') {
-            JSReceiver.onConsentUIReady(isFromPM(event));
-            return;
-        }
-        JSReceiver.onAction(JSON.stringify(consentData(event)));
-    } catch (err) {
-        JSReceiver.log(err.stack);
-    };
-};
-
-function consentData(event) {
-    return isFromPM(event) ? dataFromPM(event) : dataFromMessage(event);
-};
-
-function isFromPM(event) {
-    return event.data.fromPM || event.data.settings && event.data.settings.vendorList != null;
-};
-
-function dataFromMessage(msgEvent) {
-
-    return {
-        name: msgEvent.data.name,
-        actionType: msgEvent.data.actions.length ? msgEvent.data.actions[0].data.type : null,
-        choiceId: msgEvent.data.actions.length ? String(msgEvent.data.actions[0].data.choice_id) : null,
-        requestFromPm: false,
-        pmId: msgEvent.data.actions.length ? getPmIdFromURL(msgEvent.data.actions[0].data.iframe_url) : null,
-        saveAndExitVariables: {}
-    };
-};
-
-function dataFromPM(pmEvent) {
-    return {
-        name: pmEvent.data.name,
-        actionType: pmEvent.data ? pmEvent.data.actionType : null,
-        choiceId: null,
-        requestFromPm: true,
-        pmId: null,
-        saveAndExitVariables: pmEvent.data.payload
-    };
-};
+function isFromPM(payload) {
+    return payload.fromPM || (payload.settings && payload.settings.vendorList != null);
+}
 
 function getPmIdFromURL(url) {
     return url ? url.match(/[?&]message_id(=([^&#]*)|&|#|$)/)[2] : null;
-};
+}
 
-module.exports = handleEvent
+function actionFromMessage(payload) {
+    var actionPayload = payload.actions && payload.actions.length && payload.actions[0] && payload.actions[0].data ? payload.actions[0].data : {};
+    return {
+        name: payload.name,
+        actionType: actionPayload.type,
+        choiceId: String(actionPayload.choice_id),
+        requestFromPm: false,
+        pmId: getPmIdFromURL(actionPayload.iframe_url),
+        saveAndExitVariables: {}
+    };
+}
+
+function actionFromPM(payload) {
+    return {
+        name: payload.name,
+        actionType: payload.actionType,
+        choiceId: null,
+        requestFromPm: true,
+        pmId: null,
+        saveAndExitVariables: payload.payload
+    };
+}
+
+function actionData(payload) {
+    var data = isFromPM(payload) ? actionFromPM(payload) : actionFromMessage(payload);
+    return data;
+}
+
+function notImplemented(callbackName) {
+    return function () {
+        console.error(callbackName + ' not implemented');
+    }
+}
+
+function handleEvent(event) {
+    var payload = event.data;
+    var sdk = window.JSReceiver || {
+        onConsentUIReady: notImplemented('onCosentReady'),
+        onAction: notImplemented('onAction'),
+        onError: notImplemented('onError'),
+        log: notImplemented('log')
+    };
+    try {
+        sdk.log(JSON.stringify(payload));
+        if (payload.name === 'sp.showMessage')
+            sdk.onConsentUIReady(isFromPM(payload));
+        else
+            sdk.onAction(JSON.stringify(actionData(payload)));
+    } catch (err) {
+        sdk.onError(err.stack);
+    }
+}
+
+/*
+We export the handleEvent function inside a try-catch block
+because newer WebViews will throw an error when a variable
+is not defined. In this case, module is not defined by us
+but the Node runtime.
+*/
+try {
+    module.exports = handleEvent;
+} catch {
+  /* no-op */
+}
+
+window.addEventListener('message', handleEvent);

--- a/cmplibrary/src/test/JS/js_receiver.test.js
+++ b/cmplibrary/src/test/JS/js_receiver.test.js
@@ -7,9 +7,7 @@ var {
 
 var handleEvents = require(eventHandlerRelativePath)
 
-afterEach(() => {
-    jest.clearAllMocks();
-});
+afterEach(jest.clearAllMocks)
 
 describe("JSReceiver/EventHandler test cases:", () => {
     it("showMessage", () => {
@@ -31,17 +29,17 @@ describe("JSReceiver/EventHandler test cases:", () => {
         expect(JSReceiverMock.onAction).not.toBeCalled()
         handleEvents(eventMocks.acceptAllFromMsg)
         expect(JSReceiverMock.onAction).toBeCalledWith(JSON.stringify(expectedArgs.acceptAllFromMsg))
-    }),
+    })
     it("acceptAll from message dialog (w/ choiceId:number)", () => {
         expect(JSReceiverMock.onAction).not.toBeCalled()
         handleEvents(eventMocks.acceptAllFromMsg)
         expect(JSReceiverMock.onAction).toBeCalledWith(JSON.stringify(expectedArgs.acceptAllFromMsg))
-    }),
+    })
     it("acceptAll from message dialog (w/ choiceId:string) ", () => {
         expect(JSReceiverMock.onAction).not.toBeCalled()
         handleEvents({...eventMocks.acceptAllFromMsg,choiceId:Number(eventMocks.acceptAllFromMsg.choiceId)})
         expect(JSReceiverMock.onAction).toBeCalledWith(JSON.stringify(expectedArgs.acceptAllFromMsg))
-    }),
+    })
     it("showPm should have correct pmId", () => {
         expect(JSReceiverMock.onAction).not.toBeCalled()
         handleEvents(eventMocks.showOptions)


### PR DESCRIPTION
@leodoin if it weren't by the js_receiver.test this PR would take much longer to be done and probably would contain errors hard to catch as well. 

Fun fact of the day 💡
If we use `//` as comments in the `js_receiver` it will prevent the message from rendering with my DNS configuration.
When changing that to `/* */` style, the message would start rendering again... 🤯 