### PR TITLE
make `onNoIntentActivitiesFound` optional

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentLibBuilder.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentLibBuilder.java
@@ -29,8 +29,9 @@ public class ConsentLibBuilder {
     protected GDPRConsentLib.messageFinishedCallback messageFinished = () -> {};
     protected GDPRConsentLib.onActionCallback onAction = a -> {};
     protected GDPRConsentLib.onBeforeSendingConsent onBeforeSendingConsent = (a, c) -> c.sendConsent(a);
-    boolean stagingCampaign, shouldCleanConsentOnError;
+    protected GDPRConsentLib.OnNoIntentActivitiesFound onNoIntentActivitiesFound = url -> {};
 
+    boolean stagingCampaign, shouldCleanConsentOnError;
     SourcePointClient sourcePointClient;
 
     String targetingParamsString = null;
@@ -42,7 +43,6 @@ public class ConsentLibBuilder {
 
     PropertyConfig propertyConfig;
     private Context context;
-    public GDPRConsentLib.OnNoIntentActivitiesFound onNoIntentActivitiesFound;
 
 
     ConsentLibBuilder(Integer accountId, String property, Integer propertyId , String pmId , Context context) {


### PR DESCRIPTION
this fix app crashing (if no external Browser) when the callback is not set