### PR TITLE
[SP-5295] Add support for consent language

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentAction.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentAction.java
@@ -14,19 +14,21 @@ public class ConsentAction {
     public final String pmTab;
     public final boolean requestFromPm;
     public final JSONObject pmSaveAndExitVariables;
+    public final String consentLanguage;
     private Map pubData = new HashMap();
 
-    ConsentAction(int actionType, String choiceId, String privacyManagerId, String defaultPmTab,boolean requestFromPm, JSONObject pmSaveAndExitVariables) {
+    ConsentAction(int actionType, String choiceId, String privacyManagerId, String defaultPmTab,boolean requestFromPm, JSONObject pmSaveAndExitVariables, String consentLanguage) {
         this.actionType = ActionTypes.valueOf(actionType);
         this.choiceId = choiceId;
         this.privacyManagerId = privacyManagerId;
         this.pmTab = defaultPmTab;
         this.requestFromPm = requestFromPm;
         this.pmSaveAndExitVariables = pmSaveAndExitVariables;
+        this.consentLanguage = consentLanguage;
     }
 
     ConsentAction(int actionType, String choiceId, boolean requestFromPm, JSONObject pmSaveAndExitVariables) {
-        this(actionType, choiceId, null, null,requestFromPm, pmSaveAndExitVariables);
+        this(actionType, choiceId, null, null,requestFromPm, pmSaveAndExitVariables,null);
     }
 
     public void setPubData(Map pubData){

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentAction.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentAction.java
@@ -17,7 +17,7 @@ public class ConsentAction {
     public final String consentLanguage;
     private Map pubData = new HashMap();
 
-    ConsentAction(int actionType, String choiceId, String privacyManagerId, String defaultPmTab,boolean requestFromPm, JSONObject pmSaveAndExitVariables, String consentLanguage) {
+    ConsentAction(int actionType, String choiceId, String privacyManagerId, String defaultPmTab, boolean requestFromPm, JSONObject pmSaveAndExitVariables, String consentLanguage) {
         this.actionType = ActionTypes.valueOf(actionType);
         this.choiceId = choiceId;
         this.privacyManagerId = privacyManagerId;
@@ -28,7 +28,7 @@ public class ConsentAction {
     }
 
     ConsentAction(int actionType, String choiceId, boolean requestFromPm, JSONObject pmSaveAndExitVariables) {
-        this(actionType, choiceId, null, null,requestFromPm, pmSaveAndExitVariables,null);
+        this(actionType, choiceId, null, null, requestFromPm, pmSaveAndExitVariables, null);
     }
 
     public void setPubData(Map pubData){

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentWebView.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentWebView.java
@@ -80,7 +80,7 @@ abstract public class ConsentWebView extends WebView {
         }
 
         private ConsentAction consentAction(JSONObject actionFromJS) throws ConsentLibException {
-            return new ConsentAction(getInt("actionType", actionFromJS), getString("choiceId", actionFromJS), getString("privacyManagerId", actionFromJS), getString("pmTab",actionFromJS),CustomJsonParser.getBoolean("requestFromPm", actionFromJS), getJson("saveAndExitVariables", actionFromJS), getString("consentLanguage",actionFromJS));
+            return new ConsentAction(getInt("actionType", actionFromJS), getString("choiceId", actionFromJS), getString("privacyManagerId", actionFromJS), getString("pmTab", actionFromJS), CustomJsonParser.getBoolean("requestFromPm", actionFromJS), getJson("saveAndExitVariables", actionFromJS), getString("consentLanguage", actionFromJS));
         }
     }
 

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentWebView.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/ConsentWebView.java
@@ -80,7 +80,7 @@ abstract public class ConsentWebView extends WebView {
         }
 
         private ConsentAction consentAction(JSONObject actionFromJS) throws ConsentLibException {
-            return new ConsentAction(getInt("actionType", actionFromJS), getString("choiceId", actionFromJS), getString("privacyManagerId", actionFromJS), getString("pmTab",actionFromJS),CustomJsonParser.getBoolean("requestFromPm", actionFromJS), getJson("saveAndExitVariables", actionFromJS));
+            return new ConsentAction(getInt("actionType", actionFromJS), getString("choiceId", actionFromJS), getString("privacyManagerId", actionFromJS), getString("pmTab",actionFromJS),CustomJsonParser.getBoolean("requestFromPm", actionFromJS), getJson("saveAndExitVariables", actionFromJS), getString("consentLanguage",actionFromJS));
         }
     }
 

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
@@ -503,6 +503,7 @@ public class GDPRConsentLib {
             params.put("choiceId", action.choiceId);
             params.put("pmSaveAndExitVariables", action.pmSaveAndExitVariables);
             params.put("pubData", action.getPubData());
+            params.put("consentLanguage", action.consentLanguage);
             return params;
         } catch (JSONException e) {
             throw new ConsentLibException(e, "Error trying to build body to send consents.");

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLib.java
@@ -12,6 +12,7 @@ import org.json.JSONObject;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Locale;
 
 /**
  * Entry point class encapsulating the Consents a giving user has given to one or several vendors.
@@ -492,6 +493,7 @@ public class GDPRConsentLib {
     private JSONObject paramsToSendConsent(ConsentAction action) throws ConsentLibException {
         try {
             JSONObject params = new JSONObject();
+            String consentLanguage = action.consentLanguage != null ? action.consentLanguage : Locale.getDefault().getLanguage().toUpperCase();
             params.put("accountId", accountId);
             params.put("propertyId", propertyId);
             params.put("propertyHref", "https://" + property);
@@ -503,7 +505,7 @@ public class GDPRConsentLib {
             params.put("choiceId", action.choiceId);
             params.put("pmSaveAndExitVariables", action.pmSaveAndExitVariables);
             params.put("pubData", action.getPubData());
-            params.put("consentLanguage", action.consentLanguage);
+            params.put("consentLanguage", consentLanguage);
             return params;
         } catch (JSONException e) {
             throw new ConsentLibException(e, "Error trying to build body to send consents.");

--- a/cmplibrary/src/main/res/raw/js_receiver.js
+++ b/cmplibrary/src/main/res/raw/js_receiver.js
@@ -35,7 +35,7 @@ function actionFromPM(payload) {
         pmId: null,
         pmTab: null,
         saveAndExitVariables: payload.payload,
-        consentLanguage: payload.consentLanguage ? payload.consentLanguage : null
+        consentLanguage: payload.consentLanguage
     };
 }
 

--- a/cmplibrary/src/main/res/raw/js_receiver.js
+++ b/cmplibrary/src/main/res/raw/js_receiver.js
@@ -21,7 +21,8 @@ function actionFromMessage(payload) {
         requestFromPm: false,
         pmId: pmDetails.pmId,
         pmTab: pmDetails.pmTabShow,
-        saveAndExitVariables: {}
+        saveAndExitVariables: {},
+        consentLanguage: payload.consentLanguage
     };
 }
 
@@ -33,7 +34,8 @@ function actionFromPM(payload) {
         requestFromPm: true,
         pmId: null,
         pmTab: null,
-        saveAndExitVariables: payload.payload
+        saveAndExitVariables: payload.payload,
+        consentLanguage: payload.consentLanguage ? payload.consentLanguage : null
     };
 }
 

--- a/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/ConsentActionTest.java
+++ b/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/ConsentActionTest.java
@@ -18,6 +18,7 @@ public class ConsentActionTest {
     JSONObject pmSaveAndExitVariablesMock;
 
     String choiceIdMock = "122";
+    String consentLanguageMock = "EN";
 
     int actionTypeCodeMock = 1;
 
@@ -26,10 +27,11 @@ public class ConsentActionTest {
     //ActionType validation is not being tested as this class does not have this responsibility
     @Test
     public void ConsentActionDefaults() throws JSONException {
-        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, choiceIdMock, null, null,requestFromPmMock, pmSaveAndExitVariablesMock);
+        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, choiceIdMock, null, null,requestFromPmMock, pmSaveAndExitVariablesMock, consentLanguageMock);
         assertEquals(consentAction.actionType.code, actionTypeCodeMock);
         assertEquals(choiceIdMock, choiceIdMock);
         assertEquals(pmSaveAndExitVariablesMock, pmSaveAndExitVariablesMock);
+        assertEquals(consentAction.consentLanguage, consentLanguageMock);
 
         Map pubData = new HashMap();
         pubData.put("foo", "bar");
@@ -40,10 +42,11 @@ public class ConsentActionTest {
 
     @Test
     public void ConsentActionNulls(){
-        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, null, null, null, requestFromPmMock, null);
+        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, null, null, null, requestFromPmMock, null,null);
         assertEquals(consentAction.actionType.code, actionTypeCodeMock);
         assertNull(consentAction.choiceId);
         assertNull(consentAction.pmSaveAndExitVariables);
         assertEquals("{}",consentAction.getPubData().toString());
+        assertNull(consentAction.consentLanguage );
     }
 }

--- a/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/ConsentActionTest.java
+++ b/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/ConsentActionTest.java
@@ -27,7 +27,7 @@ public class ConsentActionTest {
     //ActionType validation is not being tested as this class does not have this responsibility
     @Test
     public void ConsentActionDefaults() throws JSONException {
-        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, choiceIdMock, null, null,requestFromPmMock, pmSaveAndExitVariablesMock, consentLanguageMock);
+        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, choiceIdMock, null, null, requestFromPmMock, pmSaveAndExitVariablesMock, consentLanguageMock);
         assertEquals(consentAction.actionType.code, actionTypeCodeMock);
         assertEquals(choiceIdMock, choiceIdMock);
         assertEquals(pmSaveAndExitVariablesMock, pmSaveAndExitVariablesMock);
@@ -41,12 +41,12 @@ public class ConsentActionTest {
     }
 
     @Test
-    public void ConsentActionNulls(){
-        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, null, null, null, requestFromPmMock, null,null);
+    public void ConsentActionNulls() {
+        ConsentAction consentAction = new ConsentAction(actionTypeCodeMock, null, null, null, requestFromPmMock, null, null);
         assertEquals(consentAction.actionType.code, actionTypeCodeMock);
         assertNull(consentAction.choiceId);
         assertNull(consentAction.pmSaveAndExitVariables);
-        assertEquals("{}",consentAction.getPubData().toString());
-        assertNull(consentAction.consentLanguage );
+        assertEquals("{}", consentAction.getPubData().toString());
+        assertNull(consentAction.consentLanguage);
     }
 }

--- a/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLibTest.java
+++ b/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLibTest.java
@@ -33,10 +33,10 @@ public class GDPRConsentLibTest {
 
     private GDPRConsentLib lib;
 
-    private ConsentAction consentActionMock = new ConsentAction(ActionTypes.ACCEPT_ALL.code, "foo", null, "null",false, new JSONObject(),"foo_en");
-    private ConsentAction consentActionMockPMDismiss = new ConsentAction(ActionTypes.PM_DISMISS.code, "foo", null, null, false, new JSONObject(),"foo_en");
-    private ConsentAction consentActionMockMsgCancel = new ConsentAction(ActionTypes.MSG_CANCEL.code, "foo", null, null,false, new JSONObject(), "foo_en");
-    private ConsentAction consentActionMockShowOptions = new ConsentAction(ActionTypes.SHOW_OPTIONS.code, "foo", "foo_pmId", "foo_pmTab",false, new JSONObject(), "foo_en");
+    private ConsentAction consentActionMock = new ConsentAction(ActionTypes.ACCEPT_ALL.code, "foo", null, "null", false, new JSONObject(), "foo_en");
+    private ConsentAction consentActionMockPMDismiss = new ConsentAction(ActionTypes.PM_DISMISS.code, "foo", null, null, false, new JSONObject(), "foo_en");
+    private ConsentAction consentActionMockMsgCancel = new ConsentAction(ActionTypes.MSG_CANCEL.code, "foo", null, null, false, new JSONObject(), "foo_en");
+    private ConsentAction consentActionMockShowOptions = new ConsentAction(ActionTypes.SHOW_OPTIONS.code, "foo", "foo_pmId", "foo_pmTab", false, new JSONObject(), "foo_en");
 
     @Mock
     Activity activityMock;

--- a/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLibTest.java
+++ b/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/GDPRConsentLibTest.java
@@ -33,10 +33,10 @@ public class GDPRConsentLibTest {
 
     private GDPRConsentLib lib;
 
-    private ConsentAction consentActionMock = new ConsentAction(ActionTypes.ACCEPT_ALL.code, "foo", null, "null",false, new JSONObject());
-    private ConsentAction consentActionMockPMDismiss = new ConsentAction(ActionTypes.PM_DISMISS.code, "foo", null, null, false, new JSONObject());
-    private ConsentAction consentActionMockMsgCancel = new ConsentAction(ActionTypes.MSG_CANCEL.code, "foo", null, null,false, new JSONObject());
-    private ConsentAction consentActionMockShowOptions = new ConsentAction(ActionTypes.SHOW_OPTIONS.code, "foo", "foo_pmId", "foo_pmTab",false, new JSONObject());
+    private ConsentAction consentActionMock = new ConsentAction(ActionTypes.ACCEPT_ALL.code, "foo", null, "null",false, new JSONObject(),"foo_en");
+    private ConsentAction consentActionMockPMDismiss = new ConsentAction(ActionTypes.PM_DISMISS.code, "foo", null, null, false, new JSONObject(),"foo_en");
+    private ConsentAction consentActionMockMsgCancel = new ConsentAction(ActionTypes.MSG_CANCEL.code, "foo", null, null,false, new JSONObject(), "foo_en");
+    private ConsentAction consentActionMockShowOptions = new ConsentAction(ActionTypes.SHOW_OPTIONS.code, "foo", "foo_pmId", "foo_pmTab",false, new JSONObject(), "foo_en");
 
     @Mock
     Activity activityMock;


### PR DESCRIPTION
- In Web message sending “consentLanguage” param in sendConsent API call, this param is captured from action event.

- In Native message sending Locale.getDefault().getLanguage() value as consentLanguage param.