### PR TITLE
Make MessageLanguage getter usable

### DIFF
--- a/cmplibrary/src/debug/java/com/sourcepoint/gdpr_cmplibrary/exception/LoggerImpl.kt
+++ b/cmplibrary/src/debug/java/com/sourcepoint/gdpr_cmplibrary/exception/LoggerImpl.kt
@@ -1,0 +1,66 @@
+@file:JvmName("LoggerFactory")
+
+package com.sourcepoint.gdpr_cmplibrary.exception
+
+import android.util.Log
+import com.example.gdpr_cmplibrary.BuildConfig
+import com.sourcepoint.gdpr_cmplibrary.enqueue
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+
+/**
+ * Factory method used to create an instance of the [Logger] interface
+ * @param networkClient network client
+ * @param errorMessageManager entity used to build the network request body
+ * @param url server url
+ */
+internal fun createLogger(
+    networkClient: OkHttpClient,
+    errorMessageManager: ErrorMessageManager,
+    url: String,
+): Logger = LoggerImpl(
+    networkClient = networkClient,
+    errorMessageManager = errorMessageManager,
+    url = url
+)
+
+/**
+ * Factory method used to create an instance of the [Logger] interface for debug purpose
+ * @param networkClient network client
+ * @param errorMessageManager entity used to build the network request body
+ * @param url server url
+ */
+internal fun createLogger4Testing(
+    info : (tag : String, msg : String) -> Unit,
+    debug : (tag : String, msg : String) -> Unit,
+    verbose : (tag : String, msg : String) -> Unit,
+    networkClient: OkHttpClient,
+    errorMessageManager: ErrorMessageManager,
+    url: String,
+): Logger = LoggerImpl(
+    info = info,
+    verbose = verbose,
+    debug = debug,
+    networkClient = networkClient,
+    errorMessageManager = errorMessageManager,
+    url = url
+)
+
+/**
+ * Implementation of [Logger]
+ */
+private class LoggerImpl(
+    val info : (tag : String, msg : String) -> Unit = { tag, msg -> Log.i(tag, msg) },
+    val debug : (tag : String, msg : String) -> Unit = { tag, msg -> Log.d(tag, msg) },
+    val verbose : (tag : String, msg : String) -> Unit = { tag, msg -> Log.v(tag, msg) },
+    val networkClient: OkHttpClient,
+    val errorMessageManager: ErrorMessageManager,
+    val url: String
+) : Logger {
+    override fun error(e: ConsentLibExceptionK) { /* No log in debug */ }
+    override fun i(tag : String, msg : String) = info(tag, msg)
+    override fun d(tag : String, msg : String) = debug(tag, msg)
+    override fun v(tag : String, msg : String) = verbose(tag, msg)
+}

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/MessageLanguage.java
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/MessageLanguage.java
@@ -46,8 +46,16 @@ public enum MessageLanguage {
     public static String[] names() {
         return Arrays.toString(MessageLanguage.values()).replaceAll("^.|.$", "").split(", ");
     }
-    public static String getName(String name) {
-        return name;
+    
+    /**
+     * Returns the internal String representation for this {@link MessageLanguage}. Note that this language String
+     * approximates the ISO 639 language String where possible. When comparing this to your system locale, you should
+     * heed the advice in {@link Locale#getLanguage()}.
+     *
+     * @return An ISO 639 language String, but uppercase. Never null, never empty
+     */
+    public String getLanguage() {
+        return language;
     }
 
     public static MessageLanguage findByName(String name){

--- a/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/exception/Logger.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/gdpr_cmplibrary/exception/Logger.kt
@@ -6,8 +6,36 @@ package com.sourcepoint.gdpr_cmplibrary.exception
 internal interface Logger {
     /**
      * The [error] method receives contains the logic to communicate with the server
+     * it is used only in production
      * @param e instance of [ConsentLibExceptionK]
      */
     fun error(e: ConsentLibExceptionK)
+
+    /**
+     * The [i] method receives contains the logic to communicate with the server
+     * it is used only in debug
+     * @param tag Used to identify the source of a log message.
+     *            It usually identifies the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+    fun i(tag : String, msg : String)
+
+    /**
+     * The [d] method receives contains the logic to communicate with the server
+     * it is used only in debug
+     * @param tag Used to identify the source of a log message.
+     *            It usually identifies the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+    fun d(tag : String, msg : String)
+
+    /**
+     * The [v] method receives contains the logic to communicate with the server
+     * it is used only in debug
+     * @param tag Used to identify the source of a log message.
+     *            It usually identifies the class or activity where the log call occurs.
+     * @param msg The message you would like logged.
+     */
+    fun v(tag : String, msg : String)
     companion object
 }

--- a/cmplibrary/src/release/java/com.sourcepoint.gdpr_cmplibrary.exception/LoggerImpl.kt
+++ b/cmplibrary/src/release/java/com.sourcepoint.gdpr_cmplibrary.exception/LoggerImpl.kt
@@ -2,6 +2,7 @@
 
 package com.sourcepoint.gdpr_cmplibrary.exception
 
+import com.example.gdpr_cmplibrary.BuildConfig
 import com.sourcepoint.gdpr_cmplibrary.enqueue
 import okhttp3.MediaType
 import okhttp3.OkHttpClient
@@ -21,12 +22,27 @@ internal fun createLogger(
 ): Logger = LoggerImpl(networkClient, errorMessageManager, url)
 
 /**
+ * Factory method used to create an instance of the [Logger] interface for debug purpose
+ * @param networkClient network client
+ * @param errorMessageManager entity used to build the network request body
+ * @param url server url
+ */
+internal fun createLogger4Testing(
+    info : (tag : String, msg : String) -> Unit,
+    debug : (tag : String, msg : String) -> Unit,
+    verbose : (tag : String, msg : String) -> Unit,
+    networkClient: OkHttpClient,
+    errorMessageManager: ErrorMessageManager,
+    url: String,
+): Logger = createLogger(networkClient, errorMessageManager, url)
+
+/**
  * Implementation of [Logger]
  */
 private class LoggerImpl(
     val networkClient: OkHttpClient,
     val errorMessageManager: ErrorMessageManager,
-    val url: String,
+    val url: String
 ) : Logger {
     override fun error(e: ConsentLibExceptionK) {
         val mediaType = MediaType.parse("application/json")
@@ -38,4 +54,7 @@ private class LoggerImpl(
 
         networkClient.newCall(request).enqueue { }
     }
+    override fun i(tag : String, msg : String) { }
+    override fun d(tag : String, msg : String) { }
+    override fun v(tag : String, msg : String) { }
 }

--- a/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/MockLogger.kt
+++ b/cmplibrary/src/test/java/com/sourcepoint/gdpr_cmplibrary/MockLogger.kt
@@ -5,4 +5,7 @@ import com.sourcepoint.gdpr_cmplibrary.exception.Logger
 
 internal class MockLogger : Logger {
     override fun error(e: ConsentLibExceptionK) {}
+    override fun i(tag: String, msg: String) { }
+    override fun d(tag: String, msg: String) { }
+    override fun v(tag: String, msg: String) { }
 }


### PR DESCRIPTION
- fixes an appearant typo in the message getter for the name
- name is now the language, so that it is usable for API consumers