### PR TITLE
[DIA-1391] Add customActionId to pm action payload

### DIFF
--- a/cmplibrary/src/main/assets/js_receiver.js
+++ b/cmplibrary/src/main/assets/js_receiver.js
@@ -42,7 +42,8 @@ function actionFromPM(payload) {
         pmId: null,
         pmTab: null,
         saveAndExitVariables: payload.payload,
-        consentLanguage: payload.consentLanguage
+        consentLanguage: payload.consentLanguage,
+        customActionId: payload.customAction
     };
 }
 


### PR DESCRIPTION
Add `customActionId` to PM's action payload to fully support custom action coming from PM

https://sourcepoint.atlassian.net/browse/DIA-1391

PS: @carmelo-iriti after merging, can you make sure to merge into v7 as well? So those changes won't be lost in the new version of the SDK.