### PR TITLE
[DIA-2106] Make UUID public on CCPAConsent

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/model/exposed/SPConsents.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/model/exposed/SPConsents.kt
@@ -51,6 +51,7 @@ internal data class GDPRConsentInternal(
 ) : GDPRConsent
 
 interface CCPAConsent {
+    val uuid: String?
     val rejectedCategories: List<String>
     val rejectedVendors: List<String>
     val status: CcpaStatus?
@@ -60,7 +61,7 @@ interface CCPAConsent {
 }
 
 internal data class CCPAConsentInternal(
-    val uuid: String? = null,
+    override val uuid: String? = null,
     override val rejectedCategories: List<String> = listOf(),
     override val rejectedVendors: List<String> = listOf(),
     override val status: CcpaStatus? = null,


### PR DESCRIPTION
**JIRA Ticket** - https://sourcepoint.atlassian.net/browse/DIA-2106

**Description**
This PR introducing exposure of UUID for CCPAConsent object, which leads to our users be able to use UUID of CCPA.