### PR TITLE
DIA-2452 remove unnecessary query params from meta-data

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
@@ -124,7 +124,7 @@ private class ServiceImpl(
         execManager.executeOnWorkerThread {
             campaignManager.authId = messageReq.authId
 
-            val metadataResponse = this.getMetaData(messageReq.toMetaDataParamReq())
+            val metadataResponse = this.getMetaData(messageReq.toMetaDataParamReq(campaigns4Config))
                 .executeOnLeft {
                     pError(it)
                     return@executeOnWorkerThread

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/MessagesApiModelExt.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/MessagesApiModelExt.kt
@@ -4,6 +4,7 @@ import com.sourcepoint.cmplibrary.data.network.converter.JsonConverter
 import com.sourcepoint.cmplibrary.data.network.converter.converter
 import com.sourcepoint.cmplibrary.data.network.util.CampaignsEnv
 import com.sourcepoint.cmplibrary.exception.CampaignType
+import com.sourcepoint.cmplibrary.model.Campaign
 import com.sourcepoint.cmplibrary.model.CampaignReq
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.* // ktlint-disable
@@ -80,12 +81,23 @@ internal fun List<CampaignReq>.toMetadataArgs(): MetaDataArg {
     return JsonConverter.converter.decodeFromJsonElement<MetaDataArg>(json)
 }
 
-internal fun MessagesParamReq.toMetaDataParamReq(): MetaDataParamReq {
+internal fun MessagesParamReq.toMetaDataParamReq(campaigns: List<CampaignReq>): MetaDataParamReq {
     return MetaDataParamReq(
         env = env,
         accountId = accountId,
         propertyId = propertyId,
-        metadata = metadataArg?.let { JsonConverter.converter.encodeToString(it) } ?: "{}",
+        metadata = JsonConverter.converter.encodeToString(MetaDataMetaDataParam(
+            gdpr = campaigns
+                .firstOrNull { it.campaignType == CampaignType.GDPR }
+                ?.let {
+                    MetaDataMetaDataParam.MetaDataCampaign(groupPmId = it.groupPmId)
+                },
+            ccpa = campaigns
+                .firstOrNull { it.campaignType == CampaignType.CCPA }
+                ?.let {
+                    MetaDataMetaDataParam.MetaDataCampaign(groupPmId = it.groupPmId)
+                }
+        )),
     )
 }
 

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/MessagesApiModelExt.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/MessagesApiModelExt.kt
@@ -4,7 +4,6 @@ import com.sourcepoint.cmplibrary.data.network.converter.JsonConverter
 import com.sourcepoint.cmplibrary.data.network.converter.converter
 import com.sourcepoint.cmplibrary.data.network.util.CampaignsEnv
 import com.sourcepoint.cmplibrary.exception.CampaignType
-import com.sourcepoint.cmplibrary.model.Campaign
 import com.sourcepoint.cmplibrary.model.CampaignReq
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.* // ktlint-disable
@@ -86,18 +85,20 @@ internal fun MessagesParamReq.toMetaDataParamReq(campaigns: List<CampaignReq>): 
         env = env,
         accountId = accountId,
         propertyId = propertyId,
-        metadata = JsonConverter.converter.encodeToString(MetaDataMetaDataParam(
-            gdpr = campaigns
-                .firstOrNull { it.campaignType == CampaignType.GDPR }
-                ?.let {
-                    MetaDataMetaDataParam.MetaDataCampaign(groupPmId = it.groupPmId)
-                },
-            ccpa = campaigns
-                .firstOrNull { it.campaignType == CampaignType.CCPA }
-                ?.let {
-                    MetaDataMetaDataParam.MetaDataCampaign(groupPmId = it.groupPmId)
-                }
-        )),
+        metadata = JsonConverter.converter.encodeToString(
+            MetaDataMetaDataParam(
+                gdpr = campaigns
+                    .firstOrNull { it.campaignType == CampaignType.GDPR }
+                    ?.let {
+                        MetaDataMetaDataParam.MetaDataCampaign(groupPmId = it.groupPmId)
+                    },
+                ccpa = campaigns
+                    .firstOrNull { it.campaignType == CampaignType.CCPA }
+                    ?.let {
+                        MetaDataMetaDataParam.MetaDataCampaign(groupPmId = it.groupPmId)
+                    }
+            )
+        ),
     )
 }
 

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/MetaDataApiModel.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/MetaDataApiModel.kt
@@ -45,6 +45,11 @@ data class MetaDataResp(
             ?: super.toString()
     }
 }
+@Serializable
+data class MetaDataMetaDataParam(val gdpr: MetaDataCampaign?, val ccpa: MetaDataCampaign?) {
+    @Serializable
+    data class MetaDataCampaign(val groupPmId: String?)
+}
 
 @Serializable
 data class MetaDataArg(


### PR DESCRIPTION
This PR removes data from the metadata query param to the meta-data endpoint. The data removed is harming our ability to cache meta-data response, thus increasing our costs and response times.