### PR TITLE
[DIA-2449] Not call onError if pv-data fails

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibImpl.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibImpl.kt
@@ -212,9 +212,9 @@ internal class SpConsentLibImpl(
                     pLogger.e(
                         "SpConsentLib",
                         """
-                    onError
-                    ${error.message}
-                """.trimIndent()
+                            onError
+                            ${error.message}
+                        """.trimIndent()
                     )
                 }
             },

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibImpl.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibImpl.kt
@@ -145,7 +145,7 @@ internal class SpConsentLibImpl(
                 consentManager.sendStoredConsentToClient()
                 clientEventManager.setAction(NativeMessageActionType.GET_MSG_NOT_CALLED)
             },
-            pSuccess = {
+            onSuccess = {
                 val list = it.toCampaignModelList(logger = pLogger)
                 clientEventManager.setCampaignsToProcess(list.size)
                 if (list.isEmpty()) {

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibImpl.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibImpl.kt
@@ -193,30 +193,52 @@ internal class SpConsentLibImpl(
                 }
             },
             pError = { throwable ->
-                if (consentManager.storedConsent) {
-                    executor.executeOnSingleThread {
-                        consentManager.sendStoredConsentToClient()
-                        clientEventManager.setAction(NativeMessageActionType.GET_MSG_ERROR)
-                    }
-                } else {
-                    (throwable as? ConsentLibExceptionK)?.let { pLogger.error(it) }
-                    val ex = throwable.toConsentLibException()
-                    spClient.onError(ex)
-                    pLogger.clientEvent(
-                        event = "onError",
-                        msg = ex.code.errorCode,
-                        content = "${throwable.message}"
-                    )
-                    pLogger.e(
-                        "SpConsentLib",
-                        """
-                    onError
-                    ${throwable.message}
-                        """.trimIndent()
-                    )
-                }
-            }
+                onErrorInMessageFlow(
+                    error = throwable
+                )
+            },
+            onErrorFromPvData = { error, shouldCallOnErrorCallback ->
+                onErrorInMessageFlow(
+                    error = error,
+                    shouldCallOnErrorCallback = shouldCallOnErrorCallback
+                )
+            },
         )
+    }
+
+    /**
+     * This method handles the error from any network call of a message flow.
+     *
+     * @param error - an error that occurred during the network call
+     * @param shouldCallOnErrorCallback - a flag that decides whether or not to invoke a callback
+     * from the [SpClient] (e.g. business requirements stating that if the error occurs in postPvData()
+     * method then the onError() callback should not be called).
+     */
+    private fun onErrorInMessageFlow(error: Throwable, shouldCallOnErrorCallback: Boolean = true) {
+        if (consentManager.storedConsent) {
+            executor.executeOnSingleThread {
+                consentManager.sendStoredConsentToClient()
+                clientEventManager.setAction(NativeMessageActionType.GET_MSG_ERROR)
+            }
+        } else {
+            (error as? ConsentLibExceptionK)?.let { pLogger.error(it) }
+            val ex = error.toConsentLibException()
+            if (shouldCallOnErrorCallback) {
+                spClient.onError(ex)
+            }
+            pLogger.clientEvent(
+                event = "onError",
+                msg = ex.code.errorCode,
+                content = "${error.message}"
+            )
+            pLogger.e(
+                "SpConsentLib",
+                """
+                    onError
+                    ${error.message}
+                """.trimIndent()
+            )
+        }
     }
 
     override fun customConsentGDPR(

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
@@ -39,7 +39,8 @@ internal interface Service : NetworkClient, CampaignManager {
         messageReq: MessagesParamReq,
         pSuccess: (MessagesResp) -> Unit,
         showConsent: () -> Unit,
-        pError: (Throwable) -> Unit
+        pError: (Throwable) -> Unit,
+        onErrorFromPvData: (Throwable, Boolean) -> Unit,
     )
 
     companion object

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
@@ -39,8 +39,8 @@ internal interface Service : NetworkClient, CampaignManager {
         messageReq: MessagesParamReq,
         pSuccess: (MessagesResp) -> Unit,
         showConsent: () -> Unit,
-        pError: (Throwable) -> Unit,
-        onErrorFromPvData: (Throwable, Boolean) -> Unit,
+        onFailure: (Throwable, Boolean) -> Unit,
+//        onErrorFromPvData: (Throwable, Boolean) -> Unit,
     )
 
     companion object

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
@@ -40,7 +40,6 @@ internal interface Service : NetworkClient, CampaignManager {
         pSuccess: (MessagesResp) -> Unit,
         showConsent: () -> Unit,
         onFailure: (Throwable, Boolean) -> Unit,
-//        onErrorFromPvData: (Throwable, Boolean) -> Unit,
     )
 
     companion object

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/Service.kt
@@ -37,7 +37,7 @@ internal interface Service : NetworkClient, CampaignManager {
 
     fun getMessages(
         messageReq: MessagesParamReq,
-        pSuccess: (MessagesResp) -> Unit,
+        onSuccess: (MessagesResp) -> Unit,
         showConsent: () -> Unit,
         onFailure: (Throwable, Boolean) -> Unit,
     )

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
@@ -119,7 +119,8 @@ private class ServiceImpl(
         messageReq: MessagesParamReq,
         pSuccess: (MessagesResp) -> Unit,
         showConsent: () -> Unit,
-        pError: (Throwable) -> Unit
+        pError: (Throwable) -> Unit,
+        onErrorFromPvData: (Throwable, Boolean) -> Unit,
     ) {
         execManager.executeOnWorkerThread {
             campaignManager.authId = messageReq.authId
@@ -233,8 +234,8 @@ private class ServiceImpl(
                 )
 
                 postPvData(pvParams)
-                    .executeOnLeft {
-                        pError(it)
+                    .executeOnLeft { gdprPvDataError ->
+                        onErrorFromPvData(gdprPvDataError, false)
                         return@executeOnWorkerThread
                     }
                     .executeOnRight { pvDataResponse ->
@@ -263,8 +264,8 @@ private class ServiceImpl(
                 )
 
                 postPvData(pvParams)
-                    .executeOnLeft {
-                        pError(it)
+                    .executeOnLeft { ccpaPvDataError ->
+                        onErrorFromPvData(ccpaPvDataError, false)
                         return@executeOnWorkerThread
                     }
                     .executeOnRight { pvDataResponse ->

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
@@ -117,7 +117,7 @@ private class ServiceImpl(
 
     override fun getMessages(
         messageReq: MessagesParamReq,
-        pSuccess: (MessagesResp) -> Unit,
+        onSuccess: (MessagesResp) -> Unit,
         showConsent: () -> Unit,
         onFailure: (Throwable, Boolean) -> Unit,
     ) {
@@ -208,7 +208,7 @@ private class ServiceImpl(
                             }
                         }
 
-                        execManager.executeOnMain { pSuccess(it) }
+                        execManager.executeOnMain { onSuccess(it) }
                     }
             } else {
                 execManager.executeOnMain { showConsent() }

--- a/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
+++ b/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
@@ -196,7 +196,7 @@ class ServiceImplTest {
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock,
+            onFailure = errorMock,
             onErrorFromPvData = onErrorFromPvDataMock,
         )
 
@@ -223,7 +223,7 @@ class ServiceImplTest {
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock,
+            onFailure = errorMock,
             onErrorFromPvData = onErrorFromPvDataMock,
         )
 
@@ -243,7 +243,7 @@ class ServiceImplTest {
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock,
+            onFailure = errorMock,
             onErrorFromPvData = onErrorFromPvDataMock,
         )
 
@@ -263,7 +263,7 @@ class ServiceImplTest {
             messageReq = messagesParamReq.copy(authId = "test"),
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock,
+            onFailure = errorMock,
             onErrorFromPvData = onErrorFromPvDataMock,
         )
 
@@ -288,7 +288,7 @@ class ServiceImplTest {
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock,
+            onFailure = errorMock,
             onErrorFromPvData = onErrorFromPvDataMock,
         )
 
@@ -333,7 +333,7 @@ class ServiceImplTest {
             messageReq = mockMessagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock,
+            onFailure = errorMock,
             onErrorFromPvData = onErrorFromPvDataMock,
         )
 
@@ -379,7 +379,7 @@ class ServiceImplTest {
             messageReq = mockMessagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock,
+            onFailure = errorMock,
             onErrorFromPvData = onErrorFromPvDataMock,
         )
 

--- a/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
+++ b/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
@@ -72,10 +72,7 @@ class ServiceImplTest {
     private lateinit var consentMockV7: () -> Unit
 
     @MockK
-    private lateinit var errorMock: (Throwable) -> Unit
-
-    @MockK
-    private lateinit var onErrorFromPvDataMock: (Throwable, Boolean) -> Unit
+    private lateinit var errorMock: (Throwable, Boolean) -> Unit
 
     private val nativeCampaign = Campaign(
         accountId = 22,
@@ -197,7 +194,6 @@ class ServiceImplTest {
             showConsent = consentMockV7,
             pSuccess = successMockV7,
             onFailure = errorMock,
-            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
 //        verify(exactly = 0) { errorMock(any()) }
@@ -224,7 +220,6 @@ class ServiceImplTest {
             showConsent = consentMockV7,
             pSuccess = successMockV7,
             onFailure = errorMock,
-            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         // TODO
@@ -244,10 +239,9 @@ class ServiceImplTest {
             showConsent = consentMockV7,
             pSuccess = successMockV7,
             onFailure = errorMock,
-            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
-        verify(exactly = 1) { errorMock(any()) }
+        verify(exactly = 1) { errorMock(any(), any()) }
         verify(exactly = 0) { successMockV7(any()) }
         verify(exactly = 0) { consentMockV7() }
     }
@@ -264,10 +258,9 @@ class ServiceImplTest {
             showConsent = consentMockV7,
             pSuccess = successMockV7,
             onFailure = errorMock,
-            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
-        verify(exactly = 1) { errorMock(any()) }
+        verify(exactly = 1) { errorMock(any(), any()) }
         verify(exactly = 0) { successMockV7(any()) }
         verify(exactly = 0) { consentMockV7() }
     }
@@ -289,10 +282,9 @@ class ServiceImplTest {
             showConsent = consentMockV7,
             pSuccess = successMockV7,
             onFailure = errorMock,
-            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
-        verify(exactly = 1) { errorMock(any()) }
+        verify(exactly = 1) { errorMock(any(), any()) }
         verify(exactly = 0) { successMockV7(any()) }
         verify(exactly = 0) { consentMockV7() }
     }
@@ -334,7 +326,6 @@ class ServiceImplTest {
             showConsent = consentMockV7,
             pSuccess = successMockV7,
             onFailure = errorMock,
-            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         // THEN
@@ -380,7 +371,6 @@ class ServiceImplTest {
             showConsent = consentMockV7,
             pSuccess = successMockV7,
             onFailure = errorMock,
-            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         // THEN

--- a/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
+++ b/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
@@ -192,7 +192,7 @@ class ServiceImplTest {
         sut.getMessages(
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
-            pSuccess = successMockV7,
+            onSuccess = successMockV7,
             onFailure = errorMock,
         )
 
@@ -218,7 +218,7 @@ class ServiceImplTest {
         sut.getMessages(
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
-            pSuccess = successMockV7,
+            onSuccess = successMockV7,
             onFailure = errorMock,
         )
 
@@ -237,7 +237,7 @@ class ServiceImplTest {
         sut.getMessages(
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
-            pSuccess = successMockV7,
+            onSuccess = successMockV7,
             onFailure = errorMock,
         )
 
@@ -256,7 +256,7 @@ class ServiceImplTest {
         sut.getMessages(
             messageReq = messagesParamReq.copy(authId = "test"),
             showConsent = consentMockV7,
-            pSuccess = successMockV7,
+            onSuccess = successMockV7,
             onFailure = errorMock,
         )
 
@@ -280,7 +280,7 @@ class ServiceImplTest {
         sut.getMessages(
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
-            pSuccess = successMockV7,
+            onSuccess = successMockV7,
             onFailure = errorMock,
         )
 
@@ -324,7 +324,7 @@ class ServiceImplTest {
         service.getMessages(
             messageReq = mockMessagesParamReq,
             showConsent = consentMockV7,
-            pSuccess = successMockV7,
+            onSuccess = successMockV7,
             onFailure = errorMock,
         )
 
@@ -369,7 +369,7 @@ class ServiceImplTest {
         service.getMessages(
             messageReq = mockMessagesParamReq,
             showConsent = consentMockV7,
-            pSuccess = successMockV7,
+            onSuccess = successMockV7,
             onFailure = errorMock,
         )
 

--- a/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
+++ b/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/ServiceImplTest.kt
@@ -74,6 +74,9 @@ class ServiceImplTest {
     @MockK
     private lateinit var errorMock: (Throwable) -> Unit
 
+    @MockK
+    private lateinit var onErrorFromPvDataMock: (Throwable, Boolean) -> Unit
+
     private val nativeCampaign = Campaign(
         accountId = 22,
         propertyName = "tcfv2.mobile.demo",
@@ -189,7 +192,13 @@ class ServiceImplTest {
         every { cm.spConfig }.returns(spConfig)
 
         val sut = Service.create(ncMock, cm, cmu, ds, logger, MockExecutorManager())
-        sut.getMessages(messageReq = messagesParamReq, showConsent = consentMockV7, pSuccess = successMockV7, pError = errorMock)
+        sut.getMessages(
+            messageReq = messagesParamReq,
+            showConsent = consentMockV7,
+            pSuccess = successMockV7,
+            pError = errorMock,
+            onErrorFromPvData = onErrorFromPvDataMock,
+        )
 
 //        verify(exactly = 0) { errorMock(any()) }
         verify(exactly = 1) { ncMock.getConsentStatus(any()) }
@@ -210,7 +219,13 @@ class ServiceImplTest {
         every { cm.spConfig }.returns(spConfig)
 
         val sut = Service.create(ncMock, cm, cmu, ds, logger, MockExecutorManager())
-        sut.getMessages(messageReq = messagesParamReq, showConsent = consentMockV7, pSuccess = successMockV7, pError = errorMock)
+        sut.getMessages(
+            messageReq = messagesParamReq,
+            showConsent = consentMockV7,
+            pSuccess = successMockV7,
+            pError = errorMock,
+            onErrorFromPvData = onErrorFromPvDataMock,
+        )
 
         // TODO
     }
@@ -228,7 +243,8 @@ class ServiceImplTest {
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock
+            pError = errorMock,
+            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         verify(exactly = 1) { errorMock(any()) }
@@ -247,7 +263,8 @@ class ServiceImplTest {
             messageReq = messagesParamReq.copy(authId = "test"),
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock
+            pError = errorMock,
+            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         verify(exactly = 1) { errorMock(any()) }
@@ -271,7 +288,8 @@ class ServiceImplTest {
             messageReq = messagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock
+            pError = errorMock,
+            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         verify(exactly = 1) { errorMock(any()) }
@@ -315,7 +333,8 @@ class ServiceImplTest {
             messageReq = mockMessagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock
+            pError = errorMock,
+            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         // THEN
@@ -360,7 +379,8 @@ class ServiceImplTest {
             messageReq = mockMessagesParamReq,
             showConsent = consentMockV7,
             pSuccess = successMockV7,
-            pError = errorMock
+            pError = errorMock,
+            onErrorFromPvData = onErrorFromPvDataMock,
         )
 
         // THEN


### PR DESCRIPTION
### Requirements
Jira Ticket - [DIA-2449](https://sourcepoint.atlassian.net/browse/DIA-2449)


### Description
This PR introduces a change to dealing with `onError()` callback from the message flow. Whenever there are an error in `postPvData` network call, the SDK **should not** invoke the `onError()` callback, but **should** onvoke all the other in-app metrics.

[DIA-2449]: https://sourcepoint.atlassian.net/browse/DIA-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ