### PR TITLE
[DIA-3253] MetaApp crash fix

### DIFF
--- a/samples/metaapp/src/main/AndroidManifest.xml
+++ b/samples/metaapp/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
 
         <activity android:name=".ui.sp.PreferencesActivity" />
         <activity android:name=".ui.demo.DemoActivity" />
+        <activity android:name=".ui.viewer.JsonViewerActivity" />
 
         <activity
             android:name=".tv.viewer.JsonViewerActivityTv"


### PR DESCRIPTION
Jira - [DIA-3253](https://sourcepoint.atlassian.net/browse/DIA-3253)

Description - accidentally removed `<activity>` in `AndroidManifest.xml`

[DIA-3253]: https://sourcepoint.atlassian.net/browse/DIA-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ