### PR TITLE
remove unused code from ConsentManagerUtils

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/consent/ConsentManagerUtils.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/consent/ConsentManagerUtils.kt
@@ -3,35 +3,19 @@ package com.sourcepoint.cmplibrary.consent
 import com.sourcepoint.cmplibrary.campaign.CampaignManager
 import com.sourcepoint.cmplibrary.core.* // ktlint-disable
 import com.sourcepoint.cmplibrary.data.local.DataStorage
-import com.sourcepoint.cmplibrary.data.network.model.optimized.ConsentStatus
 import com.sourcepoint.cmplibrary.data.network.model.optimized.toCCPAConsentInternal
 import com.sourcepoint.cmplibrary.data.network.model.optimized.toGDPRUserConsent
 import com.sourcepoint.cmplibrary.data.network.model.optimized.toUsNatConsentInternal
 import com.sourcepoint.cmplibrary.exception.InvalidConsentResponse
-import com.sourcepoint.cmplibrary.exception.Logger
 import com.sourcepoint.cmplibrary.model.exposed.* // ktlint-disable
 import com.sourcepoint.cmplibrary.util.* // ktlint-disable
-import org.json.JSONObject
-import java.text.SimpleDateFormat
-import java.util.* // ktlint-disable
 
 internal interface ConsentManagerUtils {
-
-    fun hasGdprConsent(): Boolean
-    fun hasCcpaConsent(): Boolean
-
     val gdprConsentOptimized: Either<GDPRConsentInternal>
     val ccpaConsentOptimized: Either<CCPAConsentInternal>
     val usNatConsent: Either<UsNatConsentInternal>
 
     val spStoredConsent: Either<SPConsents>
-
-    fun updateGdprConsent(
-        dataRecordedConsent: String,
-        gdprConsentStatus: ConsentStatus,
-        additionsChangeDate: String,
-        legalBasisChangeDate: String
-    ): ConsentStatus
 
     val shouldTriggerByGdprSample: Boolean
     val shouldTriggerByCcpaSample: Boolean
@@ -44,172 +28,101 @@ internal interface ConsentManagerUtils {
 
 internal fun ConsentManagerUtils.Companion.create(
     campaignManager: CampaignManager,
-    dataStorage: DataStorage,
-    logger: Logger,
-    uuid: String = UUID.randomUUID().toString()
-): ConsentManagerUtils = ConsentManagerUtilsImpl(campaignManager, dataStorage, logger, uuid)
+    dataStorage: DataStorage
+): ConsentManagerUtils = ConsentManagerUtilsImpl(campaignManager, dataStorage)
 
 private class ConsentManagerUtilsImpl(
     val cm: CampaignManager,
-    val ds: DataStorage,
-    val logger: Logger,
-    val uuid: String = UUID.randomUUID().toString()
+    val ds: DataStorage
 ) : ConsentManagerUtils {
-
-    override fun updateGdprConsent(
-        dataRecordedConsent: String,
-        gdprConsentStatus: ConsentStatus,
-        additionsChangeDate: String,
-        legalBasisChangeDate: String
-    ): ConsentStatus {
-
-        val formatter = SimpleDateFormat(CampaignManager.SIMPLE_DATE_FORMAT_PATTERN, Locale.getDefault())
-
-        val dataRecordedConsentDate = formatter.parse(dataRecordedConsent)
-        val additionsChangeDateDate = formatter.parse(additionsChangeDate)
-        val legalBasisChangeDateConsentDate = formatter.parse(legalBasisChangeDate)
-
-        val creationLessThanAdditions = dataRecordedConsentDate.before(additionsChangeDateDate)
-        val creationLessThanLegalBasis = dataRecordedConsentDate.before(legalBasisChangeDateConsentDate)
-
-        val updatedCS = gdprConsentStatus.copy()
-
-        if (creationLessThanAdditions) {
-            updatedCS.vendorListAdditions = true
-        }
-        if (creationLessThanLegalBasis) {
-            updatedCS.legalBasisChanges = true
-        }
-        if (creationLessThanAdditions || creationLessThanLegalBasis) {
-            if (updatedCS.consentedAll == true) {
-                updatedCS.granularStatus?.previousOptInAll = true
-                updatedCS.consentedAll = false
-            }
-        }
-
-        val shouldReconsent = creationLessThanAdditions || creationLessThanLegalBasis
-
-        val map = mapOf(
-            "dataRecordedConsentDate" to "$dataRecordedConsentDate",
-            "additionsChangeDateDate" to "$additionsChangeDateDate",
-            "legalBasisChangeDateConsentDate" to "$legalBasisChangeDateConsentDate",
-            "creationLessThanAdditions OR creationLessThanLegalBasis" to "$shouldReconsent",
+    override val gdprConsentOptimized: Either<GDPRConsentInternal> get() = check {
+        cm.gdprConsentStatus?.toGDPRUserConsent() ?: throw InvalidConsentResponse(
+            cause = null,
+            "The GDPR consent is null!!!"
         )
-
-        logger.computation(
-            tag = "Reconsent updateGdprConsent",
-            msg = JSONObject(map).toString(),
-            json = JSONObject(map)
-        )
-
-        return updatedCS
     }
 
-    override val gdprConsentOptimized: Either<GDPRConsentInternal>
-        get() = check {
-            cm.gdprConsentStatus?.toGDPRUserConsent() ?: throw InvalidConsentResponse(
-                cause = null,
-                "The GDPR consent is null!!!"
-            )
-        }
+    override val ccpaConsentOptimized: Either<CCPAConsentInternal> get() = check {
+        cm.ccpaConsentStatus?.toCCPAConsentInternal() ?: throw InvalidConsentResponse(
+            cause = null,
+            "The CCPA consent is null!!!"
+        )
+    }
+    override val usNatConsent: Either<UsNatConsentInternal> get() = check {
+        cm.usNatConsentData?.toUsNatConsentInternal() ?: throw InvalidConsentResponse(
+            cause = null,
+            "The UsNat consent is null!!!"
+        )
+    }
 
-    override val ccpaConsentOptimized: Either<CCPAConsentInternal>
-        get() = check {
-            cm.ccpaConsentStatus?.toCCPAConsentInternal() ?: throw InvalidConsentResponse(
-                cause = null,
-                "The CCPA consent is null!!!"
-            )
-        }
-    override val usNatConsent: Either<UsNatConsentInternal>
-        get() = check {
-            cm.usNatConsentData?.toUsNatConsentInternal() ?: throw InvalidConsentResponse(
-                cause = null,
-                "The UsNat consent is null!!!"
-            )
-        }
+    override val spStoredConsent: Either<SPConsents> get() = check {
+        val ccpaCached = ccpaConsentOptimized.getOrNull()
+        val usNatCached = usNatConsent.getOrNull()
+        val gdprCached = gdprConsentOptimized.getOrNull()
+        SPConsents(
+            gdpr = gdprCached?.let { gc -> SPGDPRConsent(consent = gc) },
+            ccpa = ccpaCached?.let { cc -> SPCCPAConsent(consent = cc) },
+            usNat = usNatCached?.let { usNatConsent -> SpUsNatConsent(consent = usNatConsent) },
+        )
+    }
 
-    override val spStoredConsent: Either<SPConsents>
-        get() = check {
-            val ccpaCached = ccpaConsentOptimized.getOrNull()
-            val usNatCached = usNatConsent.getOrNull()
-            val gdprCached = gdprConsentOptimized.getOrNull()
-            SPConsents(
-                gdpr = gdprCached?.let { gc -> SPGDPRConsent(consent = gc) },
-                ccpa = ccpaCached?.let { cc -> SPCCPAConsent(consent = cc) },
-                usNat = usNatCached?.let { usNatConsent -> SpUsNatConsent(consent = usNatConsent) },
-            )
-        }
-
-    override fun hasGdprConsent(): Boolean = ds.getGdprConsentResp() != null
-
-    override fun hasCcpaConsent(): Boolean = ds.getGdprConsentResp() != null
-
-    override val shouldTriggerByGdprSample: Boolean
-        get() {
-            return ds.gdprSamplingResult ?: kotlin.run {
-                val sampling = (ds.gdprSamplingValue * 100).toInt()
-                when {
-                    sampling <= 0 -> {
-                        ds.gdprSamplingResult = false
-                        false
-                    }
-                    sampling >= 100 -> {
-                        ds.gdprSamplingResult = true
-                        true
-                    }
-                    else -> {
-                        val num = (1 until 100).random()
-                        val res = num in (1..sampling)
-                        ds.gdprSamplingResult = res
-                        res
-                    }
-                }
+    override val shouldTriggerByGdprSample: Boolean get() = ds.gdprSamplingResult ?: run {
+        val sampling = (ds.gdprSamplingValue * 100).toInt()
+        when {
+            sampling <= 0 -> {
+                ds.gdprSamplingResult = false
+                false
+            }
+            sampling >= 100 -> {
+                ds.gdprSamplingResult = true
+                true
+            }
+            else -> {
+                val num = (1 until 100).random()
+                val res = num in (1..sampling)
+                ds.gdprSamplingResult = res
+                res
             }
         }
+    }
 
-    override val shouldTriggerByCcpaSample: Boolean
-        get() {
-            return ds.ccpaSamplingResult ?: kotlin.run {
-                val sampling = (ds.ccpaSamplingValue * 100).toInt()
-                when {
-                    sampling <= 0 -> {
-                        ds.ccpaSamplingResult = false
-                        false
-                    }
-                    sampling >= 100 -> {
-                        ds.ccpaSamplingResult = true
-                        true
-                    }
-                    else -> {
-                        val num = (1 until 100).random()
-                        val res = num in (1..sampling)
-                        ds.ccpaSamplingResult = res
-                        res
-                    }
-                }
+    override val shouldTriggerByCcpaSample: Boolean get() = ds.ccpaSamplingResult ?: run {
+        val sampling = (ds.ccpaSamplingValue * 100).toInt()
+        when {
+            sampling <= 0 -> {
+                ds.ccpaSamplingResult = false
+                false
+            }
+            sampling >= 100 -> {
+                ds.ccpaSamplingResult = true
+                true
+            }
+            else -> {
+                val num = (1 until 100).random()
+                val res = num in (1..sampling)
+                ds.ccpaSamplingResult = res
+                res
             }
         }
+    }
 
-    override val shouldTriggerByUsNatSample: Boolean
-        get() {
-            return ds.usNatSamplingResult ?: kotlin.run {
-                val sampling = (ds.usNatSamplingValue * 100).toInt()
-                when {
-                    sampling <= 0 -> {
-                        ds.usNatSamplingResult = false
-                        false
-                    }
-                    sampling >= 100 -> {
-                        ds.usNatSamplingResult = true
-                        true
-                    }
-                    else -> {
-                        val num = (1 until 100).random()
-                        val res = num in (1..sampling)
-                        ds.usNatSamplingResult = res
-                        res
-                    }
-                }
+    override val shouldTriggerByUsNatSample: Boolean get() = ds.usNatSamplingResult ?: run {
+        val sampling = (ds.usNatSamplingValue * 100).toInt()
+        when {
+            sampling <= 0 -> {
+                ds.usNatSamplingResult = false
+                false
+            }
+            sampling >= 100 -> {
+                ds.usNatSamplingResult = true
+                true
+            }
+            else -> {
+                val num = (1 until 100).random()
+                val res = num in (1..sampling)
+                ds.usNatSamplingResult = res
+                res
             }
         }
+    }
 }

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/Builder.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/Builder.kt
@@ -86,7 +86,7 @@ class Builder {
         val viewManager = ViewsManager.create(activityWeakRef, connManager, spc.messageTimeout)
         val execManager = ExecutorManager.create(appCtx)
         val urlManager: HttpUrlManager = HttpUrlManagerSingleton
-        val consentManagerUtils: ConsentManagerUtils = ConsentManagerUtils.create(campaignManager, dataStorage, logger)
+        val consentManagerUtils: ConsentManagerUtils = ConsentManagerUtils.create(campaignManager, dataStorage)
         val service: Service = Service.create(networkClient, campaignManager, consentManagerUtils, dataStorage, logger, execManager, connManager)
         val clientEventManager: ClientEventManager = ClientEventManager.create(
             logger = logger,

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/Factory.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/Factory.kt
@@ -66,7 +66,7 @@ fun makeConsentLib(
     val viewManager = ViewsManager.create(WeakReference<Activity>(activity), connManager, spConfig.messageTimeout)
     val execManager = ExecutorManager.create(appCtx)
     val urlManager: HttpUrlManager = HttpUrlManagerSingleton
-    val consentManagerUtils: ConsentManagerUtils = ConsentManagerUtils.create(campaignManager, dataStorage, logger)
+    val consentManagerUtils: ConsentManagerUtils = ConsentManagerUtils.create(campaignManager, dataStorage)
     val service: Service = Service.create(
         networkClient,
         campaignManager,

--- a/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/consent/ConsentManagerUtilsImplTest.kt
+++ b/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/consent/ConsentManagerUtilsImplTest.kt
@@ -1,20 +1,10 @@
 package com.sourcepoint.cmplibrary.consent
 
-import com.sourcepoint.cmplibrary.assertFalse
-import com.sourcepoint.cmplibrary.assertNull
-import com.sourcepoint.cmplibrary.assertTrue
 import com.sourcepoint.cmplibrary.campaign.CampaignManager
-import com.sourcepoint.cmplibrary.data.Service
 import com.sourcepoint.cmplibrary.data.local.DataStorage
-import com.sourcepoint.cmplibrary.data.network.converter.JsonConverter
-import com.sourcepoint.cmplibrary.data.network.converter.converter
-import com.sourcepoint.cmplibrary.data.network.model.optimized.ConsentStatus
-import com.sourcepoint.cmplibrary.exception.Logger
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
-import kotlinx.serialization.decodeFromString
 import org.junit.Before
-import org.junit.Test
 
 class ConsentManagerUtilsImplTest {
 
@@ -22,16 +12,10 @@ class ConsentManagerUtilsImplTest {
     private lateinit var campaignManager: CampaignManager
 
     @MockK
-    private lateinit var service: Service
-
-    @MockK
-    private lateinit var logger: Logger
-
-    @MockK
     private lateinit var dataStorage: DataStorage
 
     private val sut: ConsentManagerUtils by lazy {
-        ConsentManagerUtils.create(campaignManager, dataStorage, logger, "")
+        ConsentManagerUtils.create(campaignManager, dataStorage)
     }
 
     @Before
@@ -39,103 +23,5 @@ class ConsentManagerUtilsImplTest {
         MockKAnnotations.init(this, relaxUnitFun = true, relaxed = true)
     }
 
-    @Test
-    fun `GIVEN a recent dataRecordedConsent SET legalBasisChanges to true`() {
-        val dataRecordedConsent = "2022-10-12T14:00:00.63Z"
-        val additionsChangeDate = "2022-10-12T14:00:00.63Z"
-        val legalBasisChangeDate = "2022-10-12T14:00:01.63Z"
-        val gdprConsentStatus: ConsentStatus = JsonConverter.converter.decodeFromString(
-            """
-        {
-            "rejectedAny": false,
-            "rejectedLI": false,
-            "consentedAll": true,
-            "granularStatus": {
-              "vendorConsent": "ALL",
-              "vendorLegInt": "ALL",
-              "purposeConsent": "ALL",
-              "purposeLegInt": "ALL",
-              "previousOptInAll": false,
-              "defaultConsent": false
-            },
-            "hasConsentData": true,
-            "consentedToAny": true
-        }
-            """.trimIndent()
-        )
-        sut
-            .updateGdprConsent(dataRecordedConsent, gdprConsentStatus, additionsChangeDate, legalBasisChangeDate)
-            .run {
-                vendorListAdditions.assertNull()
-                legalBasisChanges!!.assertTrue()
-                granularStatus!!.previousOptInAll!!.assertTrue()
-            }
-    }
-
-    @Test
-    fun `GIVEN a recent dataRecordedConsent SET vendorListAdditions to true`() {
-        val dataRecordedConsent = "2022-10-12T14:00:00.63Z"
-        val additionsChangeDate = "2022-10-12T14:00:01.63Z"
-        val legalBasisChangeDate = "2022-10-12T14:00:00.63Z"
-        val gdprConsentStatus: ConsentStatus = JsonConverter.converter.decodeFromString(
-            """
-                {
-                    "rejectedAny": false,
-                    "rejectedLI": false,
-                    "consentedAll": true,
-                    "granularStatus": {
-                      "vendorConsent": "ALL",
-                      "vendorLegInt": "ALL",
-                      "purposeConsent": "ALL",
-                      "purposeLegInt": "ALL",
-                      "previousOptInAll": false,
-                      "defaultConsent": false
-                    },
-                    "hasConsentData": true,
-                    "consentedToAny": true
-                }
-            """.trimIndent()
-        )
-        sut
-            .updateGdprConsent(dataRecordedConsent, gdprConsentStatus, additionsChangeDate, legalBasisChangeDate)
-            .run {
-                vendorListAdditions!!.assertTrue()
-                legalBasisChanges.assertNull()
-                consentedAll!!.assertFalse()
-                granularStatus!!.previousOptInAll!!.assertTrue()
-            }
-    }
-
-    @Test
-    fun `GIVEN an old dataRecordedConsent VERIFY that legalBasisChanges, vendorListAdditions and previousOptInAll aren't edited`() {
-        val dataRecordedConsent = "2022-10-12T14:00:00.63Z"
-        val additionsChangeDate = "2022-10-12T14:00:00.63Z"
-        val legalBasisChangeDate = "2022-10-12T14:00:00.63Z"
-        val gdprConsentStatus: ConsentStatus = JsonConverter.converter.decodeFromString(
-            """
-                {
-                    "rejectedAny": false,
-                    "rejectedLI": false,
-                    "consentedAll": true,
-                    "granularStatus": {
-                      "vendorConsent": "ALL",
-                      "vendorLegInt": "ALL",
-                      "purposeConsent": "ALL",
-                      "purposeLegInt": "ALL",
-                      "previousOptInAll": false,
-                      "defaultConsent": false
-                    },
-                    "hasConsentData": true,
-                    "consentedToAny": true
-                }
-            """.trimIndent()
-        )
-        sut
-            .updateGdprConsent(dataRecordedConsent, gdprConsentStatus, additionsChangeDate, legalBasisChangeDate)
-            .run {
-                vendorListAdditions.assertNull()
-                legalBasisChanges.assertNull()
-                granularStatus!!.previousOptInAll!!.assertFalse()
-            }
-    }
+    // TODO: test ConsentManagerUtilsImplTest
 }


### PR DESCRIPTION
Was investigating an issue regarding GDPR's `legalBasisChangeDate` and stumbled on a bunch of unused code in the SDK. This PR removes it, tests (should) still pass.