### PR TITLE
DIA-3785 store gppData on usNatConsentData update

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/campaign/CampaignManager.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/campaign/CampaignManager.kt
@@ -637,6 +637,7 @@ private class CampaignManagerImpl(
             val serialised = value?.let { JsonConverter.converter.encodeToString(value) }
             dataStorage.run {
                 usNatConsentData = serialised
+                gppData = value?.gppData
             }
         }
 


### PR DESCRIPTION
When updating `usNat` object, GPP data on shared prefs was not being updated. 