### PR TITLE
remove translateMessage from includeData

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/includeData/IncludeData.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/network/model/optimized/includeData/IncludeData.kt
@@ -32,6 +32,5 @@ internal fun buildIncludeData(gppDataValue: JsonElement? = null) = buildJsonObje
         put("type", "RecordString")
     }
     put("GPPData", gppDataValue ?: JsonPrimitive(true))
-    put("translateMessage", true)
     put("categories", true)
 }

--- a/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/network/model/optimized/includeData/IncludeDataKtTest.kt
+++ b/cmplibrary/src/test/java/com/sourcepoint/cmplibrary/data/network/model/optimized/includeData/IncludeDataKtTest.kt
@@ -13,7 +13,6 @@ class IncludeDataKtTest {
     fun `GIVEN an include object VERIFY that contains the right objects`() {
         buildIncludeData().apply {
             containsKey("categories")
-            containsKey("translateMessage")
             containsKey("GPPData")
             containsKey("webConsentPayload")
             containsKey("campaigns")


### PR DESCRIPTION
`translateMessage` should only be used with platforms that don't rely on the rendering app for translating the message (ie. tvOS and Roku)