### PR TITLE
feat: make SPConsents.toWebViewConsentsJsonObject() public

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/model/exposed/SPConsents.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/model/exposed/SPConsents.kt
@@ -189,8 +189,7 @@ internal data class UsNatConsentInternal(
             gpcStatus = consentStatus?.granularStatus?.gpcStatus,
         )
 }
-
-internal fun SPConsents.toWebViewConsentsJsonObject(): JsonObject = buildJsonObject {
+fun SPConsents.toWebViewConsentsJsonObject(): JsonObject = buildJsonObject {
     ccpa?.consent?.let { ccpaConsent ->
         if (ccpaConsent.isWebConsentEligible()) {
             putJsonObject("ccpa") {


### PR DESCRIPTION
Hi there,

in our flutter app we would like to read out the webConsents ourselves, so we can inject them manually.

For this we need to access `SPConsents.toWebViewConsentsJsonObject()`
This change is analogous to the change recently applied to the iOS sdk (https://github.com/SourcePointUSA/ios-cmp-app/pull/560)

With this change it would allow feature parity in iOS vs android within the source point flutter plugin I'm working on at https://github.com/thekorn/sourcepoint_unified_cmp

Does it make sense?
thanks for your support

Have a nice day
Markus