### PR TITLE
setup for Chris request

### DIFF
--- a/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityKotlin.kt
+++ b/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityKotlin.kt
@@ -94,6 +94,9 @@ class MainActivityKotlin : AppCompatActivity() {
         auth_id_activity.setOnClickListener { _v: View? ->
             startActivity(Intent(this, MainActivityAuthId::class.java))
         }
+        transfer_consent_to_web_view.setOnClickListener { _v: View? ->
+            startActivity(Intent(this, WebConsentTransferTestActivity::class.java))
+        }
         custom_consent.setOnClickListener { _v: View? ->
             spConsentLib.customConsentGDPR(
                 vendors = dataProvider.customVendorList,

--- a/samples/app/src/main/res/layout/activity_main_v7.xml
+++ b/samples/app/src/main/res/layout/activity_main_v7.xml
@@ -70,11 +70,11 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
 
-<!--        <Button-->
-<!--                android:id="@+id/transfer_consent_to_web_view"-->
-<!--                android:layout_width="match_parent"-->
-<!--                android:layout_height="wrap_content"-->
-<!--                android:text="@string/transfer_consent_to_web_view"/>-->
+        <Button
+                android:id="@+id/transfer_consent_to_web_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/transfer_consent_to_web_view"/>
 
         <Button
                 android:id="@+id/refresh_btn"


### PR DESCRIPTION
In order to use WebTransferConsent feature you need:
1. tap `Transfer Consent` button (screenshot 1) (you might've got the FLM at this point, the choice doesn't matter, you can choose whatever you want)
2. new activity will be opened (screenshot 2)
3. tap `Clear` and then `Refresh` button, `Clear` button clears out local consent, `Refresh` button reopens message, if needed, you will see GDPR and CCPA UUID change (screenshot 3)
4. tap `Transfer` button to transfer consent to the webview (screenshot 4)

![image](https://github.com/SourcePointUSA/android-cmp-app/assets/132656146/23c842cd-a965-4bc5-9fce-499757bae1b2)
![image](https://github.com/SourcePointUSA/android-cmp-app/assets/132656146/bcb8cf5f-322f-4547-823d-ffb77922aa6c)
![image](https://github.com/SourcePointUSA/android-cmp-app/assets/132656146/9c5d5af2-0d68-4e21-a2e5-52d88fa05cd1)
![image](https://github.com/SourcePointUSA/android-cmp-app/assets/132656146/51745ded-382c-4f0d-93ac-ccd94d56f763)

**NOTE**
In order to change webview URL or SP config, go to `WebConsentTransferTestActivity` and change it here:
![image](https://github.com/SourcePointUSA/android-cmp-app/assets/132656146/746f433f-ae3c-4116-9f0d-eb7c5917ab91)
![image](https://github.com/SourcePointUSA/android-cmp-app/assets/132656146/581fa4fb-7341-4a74-9998-28b36362f69e)
