### PR TITLE
DIA-4068 fix consent empty on applies false

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/data/ServiceImpl.kt
@@ -404,17 +404,14 @@ private class ServiceImpl(
         consentAction: ConsentActionImpl,
         onSpConsentsSuccess: ((SPConsents) -> Unit)?
     ): Either<GdprCS> = check {
-
         var getResp: ChoiceResp? = null
-
         if (consentAction.actionType.isAcceptOrRejectAll()) {
-
             val getChoiceParamReq = GetChoiceParamReq(
                 choiceType = consentAction.actionType.toChoiceTypeParam(),
                 accountId = spConfig.accountId.toLong(),
                 propertyId = spConfig.propertyId.toLong(),
                 env = env,
-                metadataArg = campaignManager.metaDataResp?.toMetaDataArg()?.copy(ccpa = null, usNat = null,),
+                metadataArg = campaignManager.metaDataResp?.toMetaDataArg()?.copy(ccpa = null, usNat = null),
                 includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption())
             )
 
@@ -422,15 +419,15 @@ private class ServiceImpl(
                 .executeOnRight { response ->
                     response.gdpr?.let { responseGdpr ->
                         campaignManager.gdprConsentStatus = responseGdpr.copy(uuid = campaignManager.gdprConsentStatus?.uuid)
+                        val spConsents = ConsentManager.responseConsentHandler(
+                                gdpr = responseGdpr.copy(
+                                        uuid = campaignManager.gdprConsentStatus?.uuid,
+                                        applies = dataStorage.gdprApplies,
+                                ),
+                                consentManagerUtils = consentManagerUtils,
+                        )
+                        onSpConsentsSuccess?.invoke(spConsents)
                     }
-                    val spConsents = ConsentManager.responseConsentHandler(
-                        gdpr = response.gdpr?.copy(
-                            uuid = campaignManager.gdprConsentStatus?.uuid,
-                            applies = dataStorage.gdprApplies,
-                        ),
-                        consentManagerUtils = consentManagerUtils,
-                    )
-                    onSpConsentsSuccess?.invoke(spConsents)
                 }
                 .executeOnLeft { error ->
                     (error as? ConsentLibExceptionK)?.let { logger.error(error) }
@@ -443,30 +440,26 @@ private class ServiceImpl(
                 .getOrNull()
         }
 
-        val messageId: Long? = campaignManager.gdprMessageMetaData?.messageId?.toLong()
+        val shouldWaitForPost = consentAction.actionType.isAcceptOrRejectAll().not() || getResp?.gdpr == null
 
-        val body = postChoiceGdprBody(
-            sampleRate = dataStorage.gdprSamplingValue,
-            propertyId = spConfig.propertyId.toLong(),
-            messageId = messageId,
-            granularStatus = campaignManager.gdprConsentStatus?.consentStatus?.granularStatus,
-            consentAllRef = getResp?.gdpr?.consentAllRef,
-            vendorListId = getResp?.gdpr?.vendorListId,
-            saveAndExitVariables = consentAction.saveAndExitVariablesOptimized,
-            authid = authId,
-            uuid = campaignManager.gdprConsentStatus?.uuid,
-            sendPvData = dataStorage.gdprSamplingResult,
-            pubData = consentAction.pubData.toJsonObject(),
-            includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption())
-        )
-
-        val postConsentParams = PostChoiceParamReq(
+        networkClient.storeGdprChoice(PostChoiceParamReq(
             env = env,
             actionType = consentAction.actionType,
-            body = body
-        )
-
-        networkClient.storeGdprChoice(postConsentParams)
+            body = postChoiceGdprBody(
+                sampleRate = dataStorage.gdprSamplingValue,
+                propertyId = spConfig.propertyId.toLong(),
+                messageId = campaignManager.gdprMessageMetaData?.messageId?.toLong(),
+                granularStatus = campaignManager.gdprConsentStatus?.consentStatus?.granularStatus,
+                consentAllRef = getResp?.gdpr?.consentAllRef,
+                vendorListId = getResp?.gdpr?.vendorListId,
+                saveAndExitVariables = consentAction.saveAndExitVariablesOptimized,
+                authid = authId,
+                uuid = campaignManager.gdprConsentStatus?.uuid,
+                sendPvData = dataStorage.gdprSamplingResult,
+                pubData = consentAction.pubData.toJsonObject(),
+                includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption())
+            )
+        ))
             .executeOnRight { postConsentResponse ->
                 campaignManager.gdprUuid = postConsentResponse.uuid
                 campaignManager.gdprConsentStatus = campaignManager.gdprConsentStatus
@@ -475,7 +468,7 @@ private class ServiceImpl(
                 // only overwrite the consent object on Save & Exit.
                 // since the consent object was already saved on the response of the GET choice
                 // when accepting / rejecting all
-                if (consentAction.actionType.isAcceptOrRejectAll().not()) {
+                if (shouldWaitForPost) {
                     campaignManager.gdprConsentStatus = postConsentResponse
                 }
             }
@@ -483,7 +476,7 @@ private class ServiceImpl(
                 (error as? ConsentLibExceptionK)?.let { logger.error(error) }
             }
 
-        if (consentAction.actionType.isAcceptOrRejectAll().not()) {
+        if (shouldWaitForPost) {
             val spConsents = ConsentManager.responseConsentHandler(
                 gdpr = campaignManager.gdprConsentStatus?.copy(applies = dataStorage.gdprApplies),
                 consentManagerUtils = consentManagerUtils,
@@ -502,29 +495,27 @@ private class ServiceImpl(
         consentAction: ConsentActionImpl,
         onSpConsentsSuccess: ((SPConsents) -> Unit)?
     ): Either<CcpaCS> = check {
-
+        var getResp: ChoiceResp? = null
         if (consentAction.actionType.isAcceptOrRejectAll()) {
-
-            val getChoiceParamReq = GetChoiceParamReq(
+            getResp = networkClient.getChoice(GetChoiceParamReq(
                 choiceType = consentAction.actionType.toChoiceTypeParam(),
                 accountId = spConfig.accountId.toLong(),
                 propertyId = spConfig.propertyId.toLong(),
                 env = env,
-                metadataArg = campaignManager.metaDataResp?.toMetaDataArg()?.copy(gdpr = null, usNat = null,),
+                metadataArg = campaignManager.metaDataResp?.toMetaDataArg()?.copy(gdpr = null, usNat = null),
                 includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption())
-            )
-
-            networkClient.getChoice(getChoiceParamReq)
-                .executeOnRight { ccpaResponse ->
-                    campaignManager.ccpaConsentStatus = ccpaResponse.ccpa?.copy(uuid = campaignManager.ccpaConsentStatus?.uuid)
-                    val spConsents = ConsentManager.responseConsentHandler(
-                        ccpa = ccpaResponse.ccpa?.copy(
-                            uuid = campaignManager.ccpaConsentStatus?.uuid,
-                            applies = dataStorage.ccpaApplies,
-                        ),
-                        consentManagerUtils = consentManagerUtils,
-                    )
-                    onSpConsentsSuccess?.invoke(spConsents)
+            ))
+                .executeOnRight { response ->
+                    response.ccpa?.let { ccpaResponse ->
+                        campaignManager.ccpaConsentStatus = ccpaResponse.copy(uuid = campaignManager.ccpaConsentStatus?.uuid)
+                        onSpConsentsSuccess?.invoke(ConsentManager.responseConsentHandler(
+                                ccpa = ccpaResponse.copy(
+                                        uuid = campaignManager.ccpaConsentStatus?.uuid,
+                                        applies = dataStorage.ccpaApplies,
+                                ),
+                                consentManagerUtils = consentManagerUtils,
+                        ))
+                    }
                 }
                 .executeOnLeft { error ->
                     (error as? ConsentLibExceptionK)?.let { logger.error(error) }
@@ -534,29 +525,26 @@ private class ServiceImpl(
                     )
                     onSpConsentsSuccess?.invoke(spConsents)
                 }
+                .getOrNull()
         }
 
-        val messageId: Long? = campaignManager.ccpaMessageMetaData?.messageId?.toLong()
+        val shouldWaitForPost = consentAction.actionType.isAcceptOrRejectAll().not() || getResp?.ccpa == null
 
-        val body = postChoiceCcpaBody(
-            sampleRate = dataStorage.ccpaSamplingValue,
-            propertyId = spConfig.propertyId.toLong(),
-            messageId = messageId,
-            saveAndExitVariables = consentAction.saveAndExitVariablesOptimized,
-            authid = authId,
-            uuid = campaignManager.ccpaConsentStatus?.uuid,
-            sendPvData = dataStorage.ccpaSamplingResult,
-            pubData = consentAction.pubData.toJsonObject(),
-            includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption())
-        )
-
-        val postConsentParams = PostChoiceParamReq(
-            env = env,
-            actionType = consentAction.actionType,
-            body = body
-        )
-
-        networkClient.storeCcpaChoice(postConsentParams)
+        networkClient.storeCcpaChoice(PostChoiceParamReq(
+                env = env,
+                actionType = consentAction.actionType,
+                body = postChoiceCcpaBody(
+                        sampleRate = dataStorage.ccpaSamplingValue,
+                        propertyId = spConfig.propertyId.toLong(),
+                        messageId = campaignManager.ccpaMessageMetaData?.messageId?.toLong(),
+                        saveAndExitVariables = consentAction.saveAndExitVariablesOptimized,
+                        authid = authId,
+                        uuid = campaignManager.ccpaConsentStatus?.uuid,
+                        sendPvData = dataStorage.ccpaSamplingResult,
+                        pubData = consentAction.pubData.toJsonObject(),
+                        includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption())
+                )
+        ))
             .executeOnRight { postConsentResponse ->
                 campaignManager.ccpaUuid = postConsentResponse.uuid
                 campaignManager.ccpaConsentStatus =
@@ -575,7 +563,7 @@ private class ServiceImpl(
         // don't overwrite gdpr consents if the action is accept all or reject all
         // because the response from those endpoints does not contain a full consent
         // object.
-        if (consentAction.actionType.isAcceptOrRejectAll().not()) {
+        if (shouldWaitForPost) {
             val spConsents = ConsentManager.responseConsentHandler(
                 ccpa = campaignManager.ccpaConsentStatus?.copy(applies = dataStorage.ccpaApplies),
                 consentManagerUtils = consentManagerUtils,
@@ -594,28 +582,23 @@ private class ServiceImpl(
         consentAction: ConsentActionImpl,
         onSpConsentSuccess: ((SPConsents) -> Unit)?,
     ): Either<USNatConsentData> = check {
-
-        val body = postChoiceUsNatBody(
-            granularStatus = campaignManager.usNatConsentData?.consentStatus?.granularStatus,
-            messageId = campaignManager.usNatConsentData?.messageMetaData?.messageId?.toLong(),
-            saveAndExitVariables = consentAction.saveAndExitVariablesOptimized,
-            propertyId = spConfig.propertyId.toLong(),
-            pubData = consentAction.pubData.toJsonObject(),
-            sendPvData = dataStorage.usNatSamplingResult,
-            sampleRate = dataStorage.usNatSamplingValue,
-            uuid = campaignManager.usNatConsentData?.uuid,
-            vendorListId = campaignManager.metaDataResp?.usNat?.vendorListId,
-            includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption()),
-            authId = campaignManager.authId
-        )
-
-        val usNatPostChoiceParam = PostChoiceParamReq(
+        networkClient.storeUsNatChoice(PostChoiceParamReq(
             env = env,
             actionType = consentAction.actionType,
-            body = body,
-        )
-
-        networkClient.storeUsNatChoice(usNatPostChoiceParam)
+            body = postChoiceUsNatBody(
+                granularStatus = campaignManager.usNatConsentData?.consentStatus?.granularStatus,
+                messageId = campaignManager.usNatConsentData?.messageMetaData?.messageId?.toLong(),
+                saveAndExitVariables = consentAction.saveAndExitVariablesOptimized,
+                propertyId = spConfig.propertyId.toLong(),
+                pubData = consentAction.pubData.toJsonObject(),
+                sendPvData = dataStorage.usNatSamplingResult,
+                sampleRate = dataStorage.usNatSamplingValue,
+                uuid = campaignManager.usNatConsentData?.uuid,
+                vendorListId = campaignManager.metaDataResp?.usNat?.vendorListId,
+                includeData = buildIncludeData(gppDataValue = campaignManager.spConfig.getGppCustomOption()),
+                authId = campaignManager.authId
+            ),
+        ))
             .executeOnRight { postChoiceUsNatResponse ->
                 campaignManager.usNatConsentData = postChoiceUsNatResponse
             }
@@ -623,11 +606,10 @@ private class ServiceImpl(
                 (error as? ConsentLibExceptionK)?.let { logger.error(error) }
             }
 
-        val spConsents = ConsentManager.responseConsentHandler(
+        onSpConsentSuccess?.invoke(ConsentManager.responseConsentHandler(
             usNat = campaignManager.usNatConsentData?.copy(applies = dataStorage.usNatApplies),
             consentManagerUtils = consentManagerUtils,
-        )
-        onSpConsentSuccess?.invoke(spConsents)
+        ))
 
         campaignManager.usNatConsentData ?: throw InvalidConsentResponse(
             cause = null,
@@ -640,37 +622,30 @@ private class ServiceImpl(
         gdprApplies: Boolean?,
         ccpaApplies: Boolean?,
         usNatApplies: Boolean?,
-    ): Either<ConsentStatusResp> {
-        val csParams = messageReq.toConsentStatusParamReq(campaignManager)
+    ): Either<ConsentStatusResp> = getConsentStatus(messageReq.toConsentStatusParamReq(campaignManager))
+        .executeOnRight {
+            campaignManager.apply {
+                campaignManager.handleOldLocalData()
+                messagesOptimizedLocalState = it.localState
+                it.consentStatusData?.let { csd ->
+                    if (spConfig.isIncluded(GDPR)) {
+                        gdprConsentStatus = csd.gdpr?.copy(applies = gdprApplies)
+                        gdprUuid = csd.gdpr?.uuid
+                        gdprDateCreated = csd.gdpr?.dateCreated
+                        csd.gdpr?.expirationDate?.let { exDate -> dataStorage.gdprExpirationDate = exDate }
+                    }
 
-        return getConsentStatus(csParams)
-            .executeOnRight {
-                campaignManager.apply {
-                    campaignManager.handleOldLocalData()
-                    messagesOptimizedLocalState = it.localState
-                    it.consentStatusData?.let { csd ->
-                        // GDPR
-                        if (spConfig.isIncluded(GDPR)) {
-                            gdprConsentStatus = csd.gdpr?.copy(applies = gdprApplies)
-                            gdprUuid = csd.gdpr?.uuid
-                            gdprDateCreated = csd.gdpr?.dateCreated
-                            csd.gdpr?.expirationDate?.let { exDate -> dataStorage.gdprExpirationDate = exDate }
-                        }
+                    if (spConfig.isIncluded(CCPA)) {
+                        ccpaConsentStatus = csd.ccpa?.copy(applies = ccpaApplies)
+                        ccpaUuid = csd.ccpa?.uuid
+                        ccpaDateCreated = csd.ccpa?.dateCreated
+                        csd.ccpa?.expirationDate?.let { exDate -> dataStorage.ccpaExpirationDate = exDate }
+                    }
 
-                        // CCPA
-                        if (spConfig.isIncluded(CCPA)) {
-                            ccpaConsentStatus = csd.ccpa?.copy(applies = ccpaApplies)
-                            ccpaUuid = csd.ccpa?.uuid
-                            ccpaDateCreated = csd.ccpa?.dateCreated
-                            csd.ccpa?.expirationDate?.let { exDate -> dataStorage.ccpaExpirationDate = exDate }
-                        }
-
-                        // UsNat
-                        if (spConfig.isIncluded(USNAT)) {
-                            usNatConsentData = csd.usnat?.copy(applies = usNatApplies)
-                        }
+                    if (spConfig.isIncluded(USNAT)) {
+                        usNatConsentData = csd.usnat?.copy(applies = usNatApplies)
                     }
                 }
             }
+        }
     }
-}

--- a/samples/app/src/androidTest/java/com/sourcepoint/app/v6/MainActivityKotlinTest.kt
+++ b/samples/app/src/androidTest/java/com/sourcepoint/app/v6/MainActivityKotlinTest.kt
@@ -127,7 +127,7 @@ class MainActivityKotlinTest {
     private val spConfNative = config {
         accountId = 22
         propertyId = 18958
-        propertyName = "mobile.multicampaign.native.demo" // gdprPmId = 545258
+        propertyName = "mobile.multicampaign.native.demo"
         messLanguage = MessageLanguage.ENGLISH
         messageTimeout = 5000
         +(CampaignType.GDPR)
@@ -136,7 +136,7 @@ class MainActivityKotlinTest {
     private fun getSharedPrefs(activity: Activity) = PreferenceManager.getDefaultSharedPreferences(activity)
 
     @Test
-    fun given_a_USNAT_campaign_SHOW_message_and_ACCEPT_ALL() = runBlocking<Unit> {
+    fun given_a_USNAT_campaign_SHOW_message_and_ACCEPT_ALL() = runBlocking {
         val spClient = mockk<SpClient>(relaxed = true)
         loadKoinModules(
             mockModule(
@@ -245,7 +245,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_gdpr_campaign_CHECK_the_consent_from_a_second_activity() = runBlocking<Unit> {
+    fun given_a_gdpr_campaign_CHECK_the_consent_from_a_second_activity() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -276,7 +276,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_ccpa_campaign_SHOW_message_and_ACCEPT_ALL() = runBlocking<Unit> {
+    fun given_a_ccpa_campaign_SHOW_message_and_ACCEPT_ALL() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -320,7 +320,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_ccpa_campaign_CHECK_the_different_status() = runBlocking<Unit> {
+    fun given_a_ccpa_campaign_CHECK_the_different_status() = runBlocking {
 
         val spClient = SpClientMock()
 
@@ -357,7 +357,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_dgpr_campaign_SHOW_message_and_REJECT_ALL() = runBlocking<Unit> {
+    fun given_a_gdpr_campaign_SHOW_message_and_REJECT_ALL() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -404,7 +404,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_campaignList_ACCEPT_all_legislation() = runBlocking<Unit> {
+    fun given_a_campaignList_ACCEPT_all_legislation() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -459,8 +459,8 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun WITHOUT_a_stored_consent_given_no_internet_connection_exception_VERIFY_the_called_callbacks() =
-        runBlocking<Unit> {
+    fun without_a_stored_consent_given_no_internet_connection_exception_VERIFY_the_called_callbacks() =
+        runBlocking {
 
             val spClient = mockk<SpClient>(relaxed = true)
 
@@ -522,7 +522,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_campaignList_ACCEPT_all_legislation_and_verify_that_the_popup_apper_1_time() = runBlocking<Unit> {
+    fun given_a_campaignList_ACCEPT_all_legislation_and_verify_that_the_popup_appear_1_time() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -561,7 +561,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_campaign_without_pupup_to_show_VERIFY_that_the_tddata_gets_saved() = runBlocking<Unit> {
+    fun given_a_campaign_without_popup_to_show_VERIFY_that_the_tcdata_gets_saved() = runBlocking<Unit> {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -612,7 +612,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_camapignList_ACCEPT_all_legislation_from_option_button() = runBlocking<Unit> {
+    fun given_a_campaignList_ACCEPT_all_legislation_from_option_button() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -658,51 +658,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_camapignList_ACCEPT_all_legislation() = runBlocking<Unit> {
-
-        val spClient = mockk<SpClient>(relaxed = true)
-
-        loadKoinModules(
-            mockModule(
-                spConfig = spConf,
-                gdprPmId = "488393",
-                ccpaPmId = "509688",
-                spClientObserver = listOf(spClient)
-            )
-        )
-
-        scenario = launchActivity()
-
-        wr(backup = { clickOnRefreshBtnActivity() }) { tapAcceptAllOnWebView() }
-        wr { tapAcceptAllOnWebView() }
-
-        verify(exactly = 0) { spClient.onError(any()) }
-        wr { verify(exactly = 1) { spClient.onSpFinished(any()) } }
-        wr { verify(exactly = 2) { spClient.onConsentReady(any()) } }
-        wr { verify(atLeast = 2) { spClient.onUIReady(any()) } }
-        wr { verify(exactly = 2) { spClient.onAction(any(), any()) } }
-        verify(exactly = 1) { spClient.onUIFinished(any()) }
-
-        verify {
-            spClient.run {
-                onUIReady(any())
-                onSpFinished(withArg {
-                    it.ccpa!!.consent.applies.assertTrue()
-                    it.gdpr!!.consent.applies.assertTrue()
-                    it.gdpr!!.consent.consentStatus!!.consentedAll.assertNotNull()
-                    it.ccpa!!.consent.uuid.assertNotNull()
-                    it.gdpr!!.consent.uuid.assertNotNull()
-                })
-                onUIReady(any())
-                onAction(any(), any())
-                onUIReady(any())
-                onConsentReady(any())
-            }
-        }
-    }
-
-    @Test
-    fun given_consent_USING_gdpr_pm() = runBlocking<Unit> {
+    fun given_consent_USING_gdpr_pm() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -738,7 +694,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_gdpr_consent_ACCEPT_ALL() = runBlocking<Unit> {
+    fun given_a_gdpr_consent_ACCEPT_ALL() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -771,7 +727,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_deeplink_OPEN_an_activity() = runBlocking<Unit> {
+    fun given_a_deeplink_OPEN_an_activity() = runBlocking {
 
         loadKoinModules(mockModule(spConfig = spConfGdpr, gdprPmId = "488393"))
 
@@ -784,30 +740,24 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun SAVE_AND_EXIT_action() = runBlocking<Unit> {
+    fun save_and_exit_action_persists_consent() = runBlocking {
 
         loadKoinModules(mockModule(spConfig = spConfGdpr, gdprPmId = "488393"))
 
         scenario = launchActivity()
 
         wr(backup = { clickOnRefreshBtnActivity() }) { tapAcceptOnWebView() }
-//        wr {
-//            scenario.onActivity { activity ->
-//                PreferenceManager.getDefaultSharedPreferences(activity).contains("sp.gdpr.consentUUID").assertTrue()
-//            }
-//        }
         wr { clickOnGdprReviewConsent() }
         wr(backup = { clickOnGdprReviewConsent() }) { tapToDisableSomeConsent() }
         wr { tapSaveAndExitWebView() }
         delay(300)
         wr { clickOnGdprReviewConsent() }
         wr(backup = { clickOnGdprReviewConsent() }) { checkSomeConsentsOff() }
-
     }
 
 
     @Test
-    fun Appplies_usng_SAVE_AND_EXIT_action() = runBlocking<Unit> {
+    fun applies_usnat_SAVE_AND_EXIT_action() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -846,7 +796,7 @@ class MainActivityKotlinTest {
 
 
     @Test
-    fun customConsentAction() = runBlocking<Unit> {
+    fun customConsentAction() = runBlocking {
         val spClient = mockk<SpClient>(relaxed = true)
 
         loadKoinModules(
@@ -893,7 +843,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun deleteCustomConsentAction() = runBlocking<Unit> {
+    fun deleteCustomConsentAction() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -912,14 +862,14 @@ class MainActivityKotlinTest {
         wr { clickOnGdprReviewConsent() }
         wr(backup = { clickOnGdprReviewConsent() }) { checkAllGdprConsentsOn() }
         wr { tapCancelOnWebView() }
-        wr { clickOnDeleteCustomConsent() } // delete the previous custom consent
+        wr { clickOnDeleteCustomConsent() }
         wr { verify(exactly = 2) { spClient.onConsentReady(any()) } }
         wr { clickOnGdprReviewConsent() }
         wr(backup = { clickOnGdprReviewConsent() }) { checkDeletedCustomCategoriesData() }
     }
 
     @Test
-    fun given_a_camapignList_VERIFY_back_btn() = runBlocking<Unit> {
+    fun given_a_campaignList_VERIFY_back_btn() = runBlocking {
         val spClient = mockk<SpClient>(relaxed = true)
 
         loadKoinModules(
@@ -945,7 +895,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_camapignList_PRESS_cancel_VERIFY_onConsentReady_NOT_called() = runBlocking<Unit> {
+    fun given_a_campaignList_PRESS_cancel_VERIFY_onConsentReady_NOT_called() = runBlocking {
         val spClient = mockk<SpClient>(relaxed = true)
 
         loadKoinModules(
@@ -967,7 +917,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_groupId_VERIFY_that_the_right_pm_is_displayed() = runBlocking<Unit> {
+    fun given_a_groupId_VERIFY_that_the_right_pm_is_displayed() = runBlocking {
         val spClient = mockk<SpClient>(relaxed = true)
 
         loadKoinModules(
@@ -989,7 +939,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun TAPPING_on_aVENDORS_link_SHOW_the_PM_VENDORS_tab() = runBlocking<Unit> {
+    fun tapping_on_aVENDORS_link_SHOW_the_PM_VENDORS_tab() = runBlocking {
         val spClient = mockk<SpClient>(relaxed = true)
 
         loadKoinModules(
@@ -1018,7 +968,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_ccpa_if_applies_FALSE_VERIFY_USPSTRING() = runBlocking<Unit> {
+    fun given_a_ccpa_if_applies_FALSE_VERIFY_USPSTRING() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -1049,7 +999,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_ccpa_if_applies_TRUE_VERIFY_USPSTRING() = runBlocking<Unit> {
+    fun given_a_ccpa_if_applies_TRUE_VERIFY_USPSTRING() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 
@@ -1086,7 +1036,7 @@ class MainActivityKotlinTest {
     }
 
     @Test
-    fun given_a_ccpa_if_rejectedAll_from_PM_VERIFY_USPSTRING() = runBlocking<Unit> {
+    fun given_a_ccpa_if_rejectedAll_from_PM_VERIFY_USPSTRING() = runBlocking {
 
         val spClient = mockk<SpClient>(relaxed = true)
 

--- a/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityKotlin.kt
+++ b/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityKotlin.kt
@@ -347,7 +347,7 @@ class MainActivityKotlin : AppCompatActivity() {
         dataProvider.messageType
             ?.let {
                 spConsentLib.loadPrivacyManager(
-                    pmId = "1144201",
+                    pmId = dataProvider.gdprPmId,
                     pmTab = PMTab.PURPOSES,
                     campaignType = CampaignType.GDPR,
                     useGroupPmIfAvailable = dataProvider.useGdprGroupPmIfAvailable,


### PR DESCRIPTION
Fix an issue causing the consent object being empty if the user takes a consent action where the legislation `applies` field is `false`.