### PR TITLE
DIA-4713 Change `setView` argument for key-value pairs in meta-app

### DIFF
--- a/cmplibrary/src/androidTest/java/com/sourcepoint/cmplibrary/campaign/CampaignManagerImplTest.kt
+++ b/cmplibrary/src/androidTest/java/com/sourcepoint/cmplibrary/campaign/CampaignManagerImplTest.kt
@@ -166,8 +166,8 @@ class CampaignManagerImplTest {
     fun given_an_expired_GDPR_isGdprExpired_RETURN_true() {
 
         dataStorage.gdprExpirationDate = "2022-10-27T17:15:57.006Z"
-        dataStorage.ccpaExpirationDate = "2024-10-27T17:15:57.006Z"
-        campaignManager.usNatConsentData = usnatMock.copy(expirationDate = "2024-10-27T17:15:57.006Z")
+        dataStorage.ccpaExpirationDate = "2025-10-27T17:15:57.006Z"
+        campaignManager.usNatConsentData = usnatMock.copy(expirationDate = "2025-10-27T17:15:57.006Z")
 
         campaignManager.isGdprExpired.assertTrue()
         campaignManager.isCcpaExpired.assertFalse()
@@ -177,9 +177,9 @@ class CampaignManagerImplTest {
     @Test
     fun given_an_expired_CCPA_isCcpaExpired_RETURN_true() {
 
-        dataStorage.gdprExpirationDate = "2024-10-27T17:15:57.006Z"
+        dataStorage.gdprExpirationDate = "2025-10-27T17:15:57.006Z"
         dataStorage.ccpaExpirationDate = "2022-10-27T17:15:57.006Z"
-        campaignManager.usNatConsentData = usnatMock.copy(expirationDate = "2024-10-27T17:15:57.006Z")
+        campaignManager.usNatConsentData = usnatMock.copy(expirationDate = "2025-10-27T17:15:57.006Z")
 
         campaignManager.isGdprExpired.assertFalse()
         campaignManager.isCcpaExpired.assertTrue()
@@ -189,8 +189,8 @@ class CampaignManagerImplTest {
     @Test
     fun given_an_expired_USNAT_isUsnatExpired_RETURN_true() {
 
-        dataStorage.gdprExpirationDate = "2024-10-27T17:15:57.006Z"
-        dataStorage.ccpaExpirationDate = "2024-10-27T17:15:57.006Z"
+        dataStorage.gdprExpirationDate = "2025-10-27T17:15:57.006Z"
+        dataStorage.ccpaExpirationDate = "2025-10-27T17:15:57.006Z"
         campaignManager.usNatConsentData = usnatMock.copy(expirationDate = "2022-10-27T17:15:57.006Z")
 
         campaignManager.isGdprExpired.assertFalse()

--- a/samples/metaapp/src/main/java/com/sourcepointmeta/metaapp/ui/property/AddUpdatePropertyFragment.kt
+++ b/samples/metaapp/src/main/java/com/sourcepointmeta/metaapp/ui/property/AddUpdatePropertyFragment.kt
@@ -85,7 +85,7 @@ class AddUpdatePropertyFragment : Fragment() {
             val dialogBinding = AddTargetingParameterBinding.inflate(layoutInflater)
             MaterialAlertDialogBuilder(requireContext())
                 .setTitle("Add new targeting parameter")
-                .setView(R.layout.add_targeting_parameter)
+                .setView(dialogBinding.root)
                 .setPositiveButton("Create") { _, _ ->
                     val key = dialogBinding.tpKeyEd.text
                     val value = dialogBinding.tpValueEt.text
@@ -99,7 +99,7 @@ class AddUpdatePropertyFragment : Fragment() {
             val dialogBinding = AddTargetingParameterBinding.inflate(layoutInflater)
             MaterialAlertDialogBuilder(requireContext())
                 .setTitle("Add new targeting parameter")
-                .setView(R.layout.add_targeting_parameter)
+                .setView(dialogBinding.root)
                 .setPositiveButton("Create") { _, _ ->
                     val key = dialogBinding.tpKeyEd.text
                     val value = dialogBinding.tpValueEt.text
@@ -113,7 +113,7 @@ class AddUpdatePropertyFragment : Fragment() {
             val dialogBinding = AddTargetingParameterBinding.inflate(layoutInflater)
             MaterialAlertDialogBuilder(requireContext())
                 .setTitle("Add new targeting parameter")
-                .setView(R.layout.add_targeting_parameter)
+                .setView(dialogBinding.root)
                 .setPositiveButton("Create") { _, _ ->
                     val key = dialogBinding.tpKeyEd.text
                     val value = dialogBinding.tpValueEt.text


### PR DESCRIPTION
[DIA-4713](https://sourcepoint.atlassian.net/browse/DIA-4713) Key Value Pairs do not appear to save on Meta App version 7.11.0

[DIA-4713]: https://sourcepoint.atlassian.net/browse/DIA-4713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ