### PR TITLE
[DIA-5502] Fix AndroidTv navigation 

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
@@ -171,6 +171,8 @@ class SPConsentWebView(
                     )
                 )
             }
+        } else {
+            super.dispatchKeyEvent(event)
         }
         return true
     }

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
@@ -171,10 +171,10 @@ class SPConsentWebView(
                     )
                 )
             }
+            return true
         } else {
-            super.dispatchKeyEvent(event)
+            return super.dispatchKeyEvent(event)
         }
-        return true
     }
 
     override fun load(


### PR DESCRIPTION
[DIA-5502](https://sourcepoint.atlassian.net/browse/DIA-5502) [AndroidTv] Navigation Broken on 7.12.0

- [x] Use `super.dispatchKeyEvent` in case `event.keyCode` is not related to the back button

[DIA-5502]: https://sourcepoint.atlassian.net/browse/DIA-5502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ