### PR TITLE
DIA-5417 add `dismissMessageOnBackPress` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,45 +818,22 @@ A few remarks:
 2. The vendor list's consent scope needs to be set to _Shared Site_ instead of _Single Site_.
 3. Your web content needs to be loaded (or loading) on the webview and our web SDK should be included in it. Furthermore, you need to add the query param `_sp_pass_consent=true` to your URL, this will signal to Sourcepoint's web SDK it needs to wait for the consent data to be injected from the native code, instead of immediately querying it from our servers.
 
-## Navigation inside the Native OTT message
-
-Specifically for the Native OTT messages, CMP provides an inner navigation feature, that allows the users to navigate within the message by using system buttons (like back button). To make it work, the users have to utilize one of the native methods that handles back press (like overriding `onBackPressed` method in activity or using `onBackPressedDispatcher`) and `spConsentLib.handleOnBackPress()` method provided by the CMP API, for example:
-
-Kotlin (for Android 13+)
-
+## Preventing users from dismissing the consent message on back press
+When the consent message is displayed, the SDK intercepts back press events and convert those into `Dismiss` actions by default. If you wish to opt out from this behaviour, simply set `dismissMessageOnBackPress` to `false` when building the SDK:
 ```kotlin
-class YourKotlinActivity {
-    // ...
-    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
-        override fun handleOnBackPressed() {
-            spConsentLib.handleOnBackPress(isMessageDismissible = true) {
-                onBackPressedDispatcher.onBackPressed()
-            }
-        }
-    }
-    // ...
-    override fun onCreate(savedInstanceState: Bundle?) {
-        // ...
-        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
-        // ...
-    }
+private val spConsentLib by spConsentLibLazy {
+    activity = this@MainActivityKotlin
+    spClient = LocalClient()
+    dismissMessageOnBackPress = false
 }
 ```
-
-Kotlin (for the versions where `onBackPressed` is not yet deprecated)
-
-```kotlin
-class YourKotlinActivity {
-    override fun onBackPressed() {
-        spConsentLib.verifyHome(isMessageDismissible = true) { super.onBackPressed() }
-    }
-}
+Or
+```java
+private final SpConfig spConfig = new SpConfigDataBuilder()
+    ...
+    .dismissMessageOnBackPress(false)
+    .build();
 ```
-
-Regarding `handleOnBackPress` from `spConsentLib`, there are 2 parameters:
-
-- isMessageDismissible - flag that can customize the behaviour, when the user clicks back button on "Home" page of the message (if true - message is dismissible, if false - when the user is on "Home" page and clicks back, then the back event will be dispatched to the activity delegating navigation to the app)
-- onHomePage - lambda, code in which should be invoked when the user clicks back on "Home" page of the message (in other words, the initial navigation position in message)
 
 ## Programmatically rejecting all for a user
 

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLib.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLib.kt
@@ -11,6 +11,12 @@ import org.json.JSONObject
 
 interface SpConsentLib {
     /**
+     * Instructs the SDK to dismiss the message when it intercepts a back press event from
+     * within the message view. It's true by default.
+     */
+    val dismissMessageOnBackPress: Boolean
+
+    /**
      * Load the First Layer Message (FLM)
      */
     fun loadMessage()

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLib.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLib.kt
@@ -89,20 +89,24 @@ interface SpConsentLib {
     fun dispose()
 
     @Deprecated(
-        message = """
-            This method is no longer necessary.
-            The SDK can identify when a message is dismissible and act accordingly when the back button is pressed.
-            This method will be removed shortly in future releases.
-        """
+        message = "This method is deprecated and has no effect.",
+        replaceWith = ReplaceWith(
+            """
+            Set dismissMessageOnBackPress = false if you wish to prevent the user from dismissing the message
+            when the back button is pressed.
+        """"
+        )
     )
     fun handleOnBackPress(isMessageDismissible: Boolean = true, ottDelegate: SpBackPressOttDelegate)
 
     @Deprecated(
-        message = """
-            This method is no longer necessary.
-            The SDK can identify when a message is dismissible and act accordingly when the back button is pressed.
-            This method will be removed shortly in future releases.
-        """
+        message = "This method is deprecated and has no effect.",
+        replaceWith = ReplaceWith(
+            """
+            Set dismissMessageOnBackPress = false if you wish to prevent the user from dismissing the message
+            when the back button is pressed.
+        """"
+        )
     )
     fun handleOnBackPress(isMessageDismissible: Boolean = true, onHomePage: () -> Unit)
 

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibMobileCore.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibMobileCore.kt
@@ -294,23 +294,24 @@ class SpConsentLibMobileCore(
     override fun dispose() {}
 
     @Deprecated(
-        message = """
-            This method is no longer necessary.
-            The SDK can identify when a message is dismissible and act accordingly when the back button is pressed.
-            This method will be removed shortly in future releases.
-        """,
-        replaceWith = ReplaceWith("")
+        message = "This method is deprecated and has no effect.",
+        replaceWith = ReplaceWith(
+            """
+            Set dismissMessageOnBackPress = false if you wish to prevent the user from dismissing the message
+            when the back button is pressed.
+        """"
+        )
     )
-    override fun handleOnBackPress(isMessageDismissible: Boolean, ottDelegate: SpBackPressOttDelegate) {
-        handleOnBackPress(isMessageDismissible, ottDelegate::onHomePage)
-    }
+    override fun handleOnBackPress(isMessageDismissible: Boolean, ottDelegate: SpBackPressOttDelegate) {}
 
     @Deprecated(
-        message = """
-            This method is no longer necessary.
-            The SDK can identify when a message is dismissible and act accordingly when the back button is pressed.
-            This method will be removed shortly in future releases.
-        """
+        message = "This method is deprecated and has no effect.",
+        replaceWith = ReplaceWith(
+            """
+            Set dismissMessageOnBackPress = false if you wish to prevent the user from dismissing the message
+            when the back button is pressed.
+        """"
+        )
     )
     override fun handleOnBackPress(isMessageDismissible: Boolean, onHomePage: () -> Unit) {}
 

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibMobileCore.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibMobileCore.kt
@@ -67,6 +67,7 @@ class SpConsentLibMobileCore(
     private val coordinator: ICoordinator,
     private val connectionManager: ConnectionManager,
     private val spClient: SpClient,
+    override val dismissMessageOnBackPress: Boolean = true
 ) : SpConsentLib, SPMessageUIClient {
     private var pendingActions: Int = 0
     private var messagesToDisplay: ArrayDeque<MessageToDisplay> = ArrayDeque(emptyList())
@@ -78,7 +79,8 @@ class SpConsentLibMobileCore(
         SPConsentWebView.create(
             context = context,
             messageUIClient = this@SpConsentLibMobileCore,
-            propertyId = propertyId
+            propertyId = propertyId,
+            onBackPressed = dismissMessageOnBackPress
         )
     }
 

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/Factory.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/Factory.kt
@@ -26,13 +26,15 @@ fun makeConsentLib(spConfig: SpConfig, activity: Activity, spClient: SpClient) =
     spConfig = spConfig,
     activity = activity,
     spClient = spClient,
-    connectionManager = ConnectionManagerImpl(activity.applicationContext)
+    connectionManager = ConnectionManagerImpl(activity.applicationContext),
+    dismissMessageOnBackPress = true
 )
 
 fun makeConsentLib(
     spConfig: SpConfig,
     activity: Activity,
     spClient: SpClient,
+    dismissMessageOnBackPress: Boolean = true,
     connectionManager: ConnectionManager = ConnectionManagerImpl(activity.applicationContext),
 ): SpConsentLib = SpConsentLibMobileCore(
     coordinator = Coordinator(
@@ -52,7 +54,8 @@ fun makeConsentLib(
     spClient = spClient,
     context = activity.applicationContext,
     activity = WeakReference(activity),
-    connectionManager = connectionManager
+    connectionManager = connectionManager,
+    dismissMessageOnBackPress = dismissMessageOnBackPress
 )
 
 fun List<SpCampaign>.toCore(spConfig: SpConfig) = SPCampaigns(

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/SpCmpBuilder.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/SpCmpBuilder.kt
@@ -14,13 +14,13 @@ class SpCmpBuilder {
     lateinit var activity: Activity
     lateinit var spClient: SpClient
     var connectionManager: ConnectionManager? = null
+    var dismissMessageOnBackPress = true
 
     fun config(dsl: SpConfigDataBuilder.() -> Unit) {
         spConfig = SpConfigDataBuilder().apply(dsl).build()
     }
 
     internal fun build(): SpConsentLib {
-
         if (!this::activity.isInitialized) throw RuntimeException("activity param must be initialised!!!")
         if (!this::spConfig.isInitialized) throw RuntimeException("spConfig param must be initialised!!!")
 
@@ -28,7 +28,8 @@ class SpCmpBuilder {
             spConfig = spConfig,
             activity = activity,
             spClient = spClient,
-            connectionManager = connectionManager ?: ConnectionManagerImpl(activity.applicationContext)
+            connectionManager = connectionManager ?: ConnectionManagerImpl(activity.applicationContext),
+            dismissMessageOnBackPress = dismissMessageOnBackPress
         )
     }
 }

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/SpConfigDataBuilder.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/SpConfigDataBuilder.kt
@@ -127,9 +127,7 @@ class SpConfigDataBuilder {
     )
 }
 
-fun config(dsl: SpConfigDataBuilder.() -> Unit): SpConfig {
-    return SpConfigDataBuilder().apply(dsl).build()
-}
+fun config(dsl: SpConfigDataBuilder.() -> Unit) = SpConfigDataBuilder().apply(dsl).build()
 
 enum class ConfigOption(option: String) {
     TRANSITION_CCPA_AUTH("transitionCCPAAuth"),

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/SpConfigDataBuilder.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/creation/SpConfigDataBuilder.kt
@@ -1,3 +1,4 @@
+@file:Suppress("unused")
 package com.sourcepoint.cmplibrary.creation
 
 import com.sourcepoint.cmplibrary.data.network.util.CampaignType
@@ -22,6 +23,7 @@ class SpConfigDataBuilder {
     var campaignsEnv: CampaignsEnv = CampaignsEnv.PUBLIC
     var messageTimeout: Long = 5000
     var spGppConfig: SpGppConfig? = null
+    var dismissMessageOnBackPress: Boolean = true
 
     operator fun CampaignType.unaryPlus() {
         campaigns.add(SpCampaign(this, emptyList()))
@@ -107,6 +109,10 @@ class SpConfigDataBuilder {
 
     fun addCampaign(campaign: SpCampaign) = apply {
         campaigns.add(campaign)
+    }
+
+    fun dismissMessageOnBackPress(dismiss: Boolean) = apply {
+        this.dismissMessageOnBackPress = dismiss
     }
 
     fun build() = SpConfig(

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/PMUrlBuilder.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/PMUrlBuilder.kt
@@ -27,7 +27,6 @@ val basePmPaths = mapOf(
     ),
 )
 
-// TODO: guard against not finding the correct path for the campaign/pm type?
 fun basePmUrlFor(campaignType: CampaignType, pmType: MessageType) =
     "https://cdn.privacy-mgmt.com/" + (basePmPaths[campaignType]?.get(pmType) ?: "")
 
@@ -64,4 +63,8 @@ fun buildPMUrl(
             .build()
             .toString()
     }
+}
+
+fun Uri.Builder.appendQueryParameterIfPresent(name: String, value: String?) = apply {
+    value?.let { appendQueryParameter(name, it) }
 }

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
@@ -79,11 +79,6 @@ interface SPWebMessageUIClient : SPMessageUIClient {
     fun onError(error: String)
 }
 
-fun Uri.Builder.appendQueryParameterIfPresent(name: String, value: String?): Uri.Builder {
-    value?.let { appendQueryParameter(name, it) }
-    return this
-}
-
 @SuppressLint("ViewConstructor", "SetJavaScriptEnabled")
 class SPConsentWebView(
     context: Context,

--- a/samples/app/build.gradle
+++ b/samples/app/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 
     // kotlin
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:2.0.0"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:2.1.0"
 
     implementation "androidx.appcompat:appcompat:1.7.0"
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"

--- a/samples/app/src/androidTest/java/com/sourcepoint/app/v6/MainActivityKotlinTest.kt
+++ b/samples/app/src/androidTest/java/com/sourcepoint/app/v6/MainActivityKotlinTest.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.launchActivity
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.example.uitestutil.assertEquals
 import com.example.uitestutil.assertFalse
 import com.example.uitestutil.assertNotEquals
@@ -871,6 +873,22 @@ class MainActivityKotlinTest {
         wr { tapAcceptAllOnWebView() }
 
         verify(atLeast = 4) { spClient.onAction(any(), any()) }
+    }
+
+    @Test
+    fun dismissOnBackPress_when_set_to_false_prevents_the_message_from_being_dismissed() = runBlocking {
+        val spClient = mockk<SpClient>(relaxed = true)
+        loadKoinModules(
+            mockModule(
+                spConfig = spConfGdpr,
+                spClientObserver = listOf(spClient),
+                dismissMessageOnBackPress = false
+            )
+        )
+        scenario = launchActivity()
+
+        wr { UiDevice.getInstance(InstrumentationRegistry.getInstrumentation()).pressBack() }
+        wr { checkWebViewDisplayedGDPRFirstLayerMessage() }
     }
 
     @Test

--- a/samples/app/src/androidTest/java/com/sourcepoint/app/v6/TestUseCase.kt
+++ b/samples/app/src/androidTest/java/com/sourcepoint/app/v6/TestUseCase.kt
@@ -26,7 +26,7 @@ import com.sourcepoint.cmplibrary.SpClient
 import com.sourcepoint.cmplibrary.data.network.connection.ConnectionManager
 import com.sourcepoint.cmplibrary.model.exposed.MessageType
 import com.sourcepoint.cmplibrary.model.exposed.SpConfig
-import org.koin.core.module.Module
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 class TestUseCase {
@@ -236,27 +236,27 @@ class TestUseCase {
             diagnostic: List<Pair<String, Any?>> = emptyList(),
             connectionManager: ConnectionManager = object : ConnectionManager {
                 override val isConnected = true
-            }
-        ): Module {
-            return module {
-                single<List<SpClient?>> { spClientObserver }
-                single<DataProvider> {
-                    object : DataProvider {
-                        override val authId = pAuthId
-                        override val resetAll = pResetAll
-                        override val useGdprGroupPmIfAvailable: Boolean = useGdprGroupPmIfAvailable
-                        override val url = url
-                        override val spConfig: SpConfig = spConfig
-                        override val gdprPmId: String = gdprPmId
-                        override val ccpaPmId: String = ccpaPmId
-                        override val messageType: MessageType = messageType
-                        override val customVendorList: List<String> = customVendorDataListProd.map { it.first }
-                        override val customCategories: List<String> = customCategoriesDataProd.map { it.first }
-                        override val diagnostic: List<Pair<String, Any?>> = diagnostic
-                    }
+            },
+            dismissMessageOnBackPress: Boolean = true,
+        ) = module {
+            single<List<SpClient?>> { spClientObserver }
+            single<DataProvider> {
+                object : DataProvider {
+                    override val authId = pAuthId
+                    override val resetAll = pResetAll
+                    override val useGdprGroupPmIfAvailable: Boolean = useGdprGroupPmIfAvailable
+                    override val url = url
+                    override val spConfig: SpConfig = spConfig
+                    override val gdprPmId: String = gdprPmId
+                    override val ccpaPmId: String = ccpaPmId
+                    override val messageType: MessageType = messageType
+                    override val customVendorList: List<String> = customVendorDataListProd.map { it.first }
+                    override val customCategories: List<String> = customCategoriesDataProd.map { it.first }
+                    override val diagnostic: List<Pair<String, Any?>> = diagnostic
                 }
-                single { connectionManager }
             }
+            single { connectionManager }
+            single(named("dismissMessageOnBackPress")) { dismissMessageOnBackPress }
         }
     }
 }

--- a/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityKotlin.kt
+++ b/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityKotlin.kt
@@ -27,6 +27,7 @@ import com.sourcepoint.cmplibrary.model.exposed.NativeMessageActionType
 import com.sourcepoint.cmplibrary.model.exposed.SPConsents
 import org.json.JSONObject
 import org.koin.android.ext.android.inject
+import org.koin.core.qualifier.named
 
 class MainActivityKotlin : AppCompatActivity() {
 
@@ -42,12 +43,14 @@ class MainActivityKotlin : AppCompatActivity() {
     private val dataProvider by inject<DataProvider>()
     private val spClientObserver: List<SpClient> by inject()
     private val cManager: ConnectionManager by inject()
+    private val injectedDismissMessageOnBackPress: Boolean by inject(named("dismissMessageOnBackPress"))
 
     private val spConsentLib by spConsentLibLazy {
         activity = this@MainActivityKotlin
         spClient = LocalClient()
         spConfig = dataProvider.spConfig
         connectionManager = cManager
+        dismissMessageOnBackPress = injectedDismissMessageOnBackPress // true by default
 //        config {
 //            accountId = 22
 //            propertyId = 16893

--- a/samples/app/src/main/java/com/sourcepoint/app/v6/di/AppModule.kt
+++ b/samples/app/src/main/java/com/sourcepoint/app/v6/di/AppModule.kt
@@ -27,7 +27,6 @@ val customCategoriesDataProd = listOf(
 )
 
 val appModule = module {
-
     single<DataProvider> {
         val gdprPmId = "488393" // stage "13111"
         val ccpaPmId = "509688" // "14967"
@@ -87,4 +86,6 @@ val appModule = module {
     single<ConnectionManager> { object : ConnectionManager {
         override val isConnected = true
     } }
+
+    single<Boolean>(named("dismissMessageOnBackPress")) { true }
 }


### PR DESCRIPTION
Now when `dismissMessageOnBackPress = false` the SDK won't dismiss the message when the back button is pressed. This value is `true` by default, ie. sdk dismisses the message by default.