### PR TITLE
DIA-5954 implement `onMessageInactivityTimeout ` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Kotlin
         override fun onConsentReady(consent: SPConsents) { }
         override fun onAction(view: View, consentAction: ConsentAction): ConsentAction = consentAction
         override fun onNoIntentActivitiesFound(url: String) {}
+        override fun onMessageInactivityTimeout() { }
         override fun onSpFinished(sPConsents: SPConsents) { }
     }
 ```
@@ -201,6 +202,9 @@ Java
         }
 
         @Override
+        public void onMessageInactivityTimeout() { }
+
+        @Override
         public void onSpFinished(@NotNull SPConsents sPConsents) { }
     }
 ```
@@ -213,17 +217,18 @@ Meaning of the callbacks :
 - `onError`: the client has access to the error details. [See `onError` codes](#onerror-codes)
 - `onUIReady`: the consent view should be inflated;
 - `onAction`: the client receives the selected action type and has the chance to set the `pubData` fields;
+- `onMessageInactivityTimeout`: called when the user becomes inactive while viewing a consent message;
 - `onSpFinished`: there is nothing to process, all the work is done.
 
 Some of the above callbacks work on the main thread while others are work on a worker thread. Please see the table below for the distinction:
 
 | Main thread            | Worker thread  |
 | ---------------------- | -------------- |
-| `onUIReady`            | `onSpFinished` |
-| `onError`              | `onAction`     |
-| `onConsentReady`       |                |
-| `onNativeMessageReady` |                |
-| `onUIFinished`         |                |
+| `onUIReady`                  | `onSpFinished`             |
+| `onError`                    | `onAction`                 |
+| `onConsentReady`             | `onMessageInactivityTimeout` |
+| `onNativeMessageReady`       |                            |
+| `onUIFinished`               |                            |
 
 ### onError codes
 

--- a/cmplibrary/src/main/assets/js_receiver.js
+++ b/cmplibrary/src/main/assets/js_receiver.js
@@ -62,7 +62,7 @@ function handleEvent(event) {
         onAction: notImplemented('onAction'),
         onError: notImplemented('onError'),
         log: notImplemented('log'),
-        onUserInactive: notImplemented('onUserInactive'),
+        onMessageInactivityTimeout: notImplemented('onMessageInactivityTimeout'),
     };
     try {
         switch (payload.name) {
@@ -84,7 +84,7 @@ function handleEvent(event) {
                 sdk.readyForConsentPreload();
                 break;
             case 'sp.userInactive':
-                sdk.onUserInactive();
+                sdk.onMessageInactivityTimeout();
                 break;
             default:
                 sdk.log("Unexpected event name: " + JSON.stringify(payload));

--- a/cmplibrary/src/main/assets/js_receiver.js
+++ b/cmplibrary/src/main/assets/js_receiver.js
@@ -62,6 +62,7 @@ function handleEvent(event) {
         onAction: notImplemented('onAction'),
         onError: notImplemented('onError'),
         log: notImplemented('log'),
+        onUserInactive: notImplemented('onUserInactive'),
     };
     try {
         switch (payload.name) {
@@ -81,6 +82,9 @@ function handleEvent(event) {
                 break;
             case 'sp.readyForPreloadConsent':
                 sdk.readyForConsentPreload();
+                break;
+            case 'sp.userInactive':
+                sdk.onUserInactive();
                 break;
             default:
                 sdk.log("Unexpected event name: " + JSON.stringify(payload));

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpClient.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpClient.kt
@@ -39,7 +39,7 @@ interface SpClient {
     /**
      * This callback is invoked when the user becomes inactive in the rendering app.
      */
-    fun onUserInactive()
+    fun onMessageInactivityTimeout()
 }
 
 interface UnitySpClient : SpClient {

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpClient.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpClient.kt
@@ -16,10 +16,10 @@ interface SpClient {
     /**
      * It is invoked when the message is available to the client App
      */
-    fun onNativeMessageReady(message: MessageStructure, messageController: NativeMessageController)
+    fun onNativeMessageReady(message: MessageStructure, messageController: NativeMessageController) {}
 
     @Deprecated("onMessageReady callback will be removed in favor of onMessageReady(message: MessageStructure, messageController: NativeMessageController). Currently this callback is disabled.")
-    fun onMessageReady(message: JSONObject)
+    fun onMessageReady(message: JSONObject) {}
     fun onAction(view: View, consentAction: ConsentAction): ConsentAction
 
     fun onUIFinished(view: View)
@@ -39,7 +39,7 @@ interface SpClient {
     /**
      * This callback is invoked when the user becomes inactive in the rendering app.
      */
-    fun onMessageInactivityTimeout()
+    fun onMessageInactivityTimeout() {}
 }
 
 interface UnitySpClient : SpClient {

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpClient.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpClient.kt
@@ -35,6 +35,11 @@ interface SpClient {
      * This callback is invoked if no activity could open an intent with the given url.
      */
     fun onNoIntentActivitiesFound(url: String)
+
+    /**
+     * This callback is invoked when the user becomes inactive in the rendering app.
+     */
+    fun onUserInactive()
 }
 
 interface UnitySpClient : SpClient {

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibMobileCore.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLibMobileCore.kt
@@ -385,4 +385,8 @@ class SpConsentLibMobileCore(
         runOnMain { spClient.onUIFinished(view) }
         renderNextMessageIfAny()
     }
+
+    override fun onMessageInactivityTimeout() {
+        runOnMain { spClient.onMessageInactivityTimeout() }
+    }
 }

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import com.sourcepoint.cmplibrary.SpClient
 import com.sourcepoint.cmplibrary.data.network.util.CampaignType
 import com.sourcepoint.cmplibrary.exception.ConsentLibExceptionK
 import com.sourcepoint.cmplibrary.exception.NoIntentFoundForUrl
@@ -81,6 +82,7 @@ interface SPWebMessageUIClient : SPMessageUIClient {
     fun onAction(actionData: String)
     fun log(message: String)
     fun onError(error: String)
+    fun onUserInactive()
 }
 
 @SuppressLint("ViewConstructor", "SetJavaScriptEnabled")
@@ -355,4 +357,9 @@ class SPConsentWebView(
 
     @JavascriptInterface
     override fun log(message: String) = println(message)
+
+    @JavascriptInterface
+    override fun onUserInactive() = runOnMain {
+        (messageUIClient as? SpClient)?.onUserInactive()
+    }
 }

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
@@ -82,7 +82,7 @@ interface SPWebMessageUIClient : SPMessageUIClient {
     fun onAction(actionData: String)
     fun log(message: String)
     fun onError(error: String)
-    fun onUserInactive()
+    fun onMessageInactivityTimeout()
 }
 
 @SuppressLint("ViewConstructor", "SetJavaScriptEnabled")
@@ -359,7 +359,7 @@ class SPConsentWebView(
     override fun log(message: String) = println(message)
 
     @JavascriptInterface
-    override fun onUserInactive() = runOnMain {
-        (messageUIClient as? SpClient)?.onUserInactive()
+    override fun onMessageInactivityTimeout() = runOnMain {
+        (messageUIClient as? SpClient)?.onMessageInactivityTimeout()
     }
 }

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/mobile_core/SPConsentWebView.kt
@@ -46,6 +46,7 @@ interface SPMessageUIClient {
     fun onAction(view: View, action: ConsentAction)
     fun onError(error: ConsentLibExceptionK)
     fun finished(view: View)
+    fun onMessageInactivityTimeout()
 }
 
 interface SPMessageUI {
@@ -82,7 +83,6 @@ interface SPWebMessageUIClient : SPMessageUIClient {
     fun onAction(actionData: String)
     fun log(message: String)
     fun onError(error: String)
-    fun onMessageInactivityTimeout()
 }
 
 @SuppressLint("ViewConstructor", "SetJavaScriptEnabled")
@@ -360,6 +360,6 @@ class SPConsentWebView(
 
     @JavascriptInterface
     override fun onMessageInactivityTimeout() = runOnMain {
-        (messageUIClient as? SpClient)?.onMessageInactivityTimeout()
+        messageUIClient.onMessageInactivityTimeout()
     }
 }

--- a/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityJava.java
+++ b/samples/app/src/main/java/com/sourcepoint/app/v6/MainActivityJava.java
@@ -100,7 +100,6 @@ public class MainActivityJava extends AppCompatActivity {
     }
 
     class LocalClient implements SpClient {
-
         @Override
         public void onConsentReady(@NotNull SPConsents consent) {
             Map<String, GDPRPurposeGrants> grants = consent.getGdpr().getConsent().getGrants();
@@ -149,6 +148,8 @@ public class MainActivityJava extends AppCompatActivity {
         public void onNoIntentActivitiesFound(@NotNull String url) {
 
         }
-    }
 
+        @Override
+        public void onMessageInactivityTimeout() {}
+    }
 }


### PR DESCRIPTION
The message builder for Preferences messages, now has a setting to add a timeout to dispatch an event in case the user is inactive for X seconds.

When this happens, the rendering app dispatches the event `sp.userInactive` and the SDK ultimately calls the new callback `onMessageInactivityTimeout`.