### PR TITLE
remove isCoreLibraryDesugaring

### DIFF
--- a/cmplibrary/build.gradle.kts
+++ b/cmplibrary/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 
-    // https://mvnrepository.com/artifact/com.android.tools/desugar_jdk_libs
     testImplementation("org.json:json:20250107")
     testImplementation("junit:junit:4.13.2")
 }

--- a/cmplibrary/build.gradle.kts
+++ b/cmplibrary/build.gradle.kts
@@ -40,7 +40,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-        isCoreLibraryDesugaringEnabled = true
     }
     namespace = "com.example.cmplibrary"
     testNamespace = "com.sourcepoint.cmplibrary"
@@ -62,7 +61,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
 
     // https://mvnrepository.com/artifact/com.android.tools/desugar_jdk_libs
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
     testImplementation("org.json:json:20250107")
     testImplementation("junit:junit:4.13.2")
 }

--- a/integration_tests/build.gradle.kts
+++ b/integration_tests/build.gradle.kts
@@ -28,7 +28,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = "11"
@@ -40,5 +39,4 @@ dependencies {
     implementation("com.sourcepoint:core:0.1.8")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
 }

--- a/samples/app/build.gradle
+++ b/samples/app/build.gradle
@@ -41,7 +41,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
-        coreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = '11'
@@ -74,7 +73,6 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:1.7.1"
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
     implementation(Libs.androidxCore)
 
     implementation project(":cmplibrary")

--- a/ui-test-util/build.gradle
+++ b/ui-test-util/build.gradle
@@ -15,7 +15,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
-        coreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = '11'
@@ -23,8 +22,6 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
 


### PR DESCRIPTION
Removing `coreLibraryDesugaring` since it's no longer needed. It affects performance, compatibility and bundle size of our SDK. 