### PR TITLE
DIA-5932 fix legacy data migration causing re-messaging

### DIFF
--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/legacy/TransferFromNativeSDK.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/legacy/TransferFromNativeSDK.kt
@@ -50,6 +50,7 @@ fun removeLegacyData(preferences: SharedPreferences) {
         remove(LegacyGDPRChildPmId.PREFS_KEY)
         remove(LegacyCCPAChildPmId.PREFS_KEY)
         remove(LegacyUSNATChildPmId.PREFS_KEY)
+        unusedSPKeys.forEach { remove(it) }
         commit()
     }
 }
@@ -420,3 +421,13 @@ class LegacyUSNATChildPmId {
         const val PREFS_KEY = "sp.usnat.key.childPmId"
     }
 }
+
+private val unusedSPKeys = listOf(
+    "sp.gdpr.key.expiration.date",
+    "sp.ccpa.key.expiration.date",
+    "sp.usnat.key.expiration.date",
+    "sp.gdpr.consentUUID",
+    "sp.ccpa.consentUUID",
+    "sp.usnat.consentUUID",
+    "sp.key.config.propertyId"
+)


### PR DESCRIPTION
Some properties don't have GCM configured and code responsible for transferring legacy data assumed this property was not optional. 

Parsing the json string for legacy GDPR data would fail, causing the SDK to start from a new state and re-message the user.