### PR TITLE
DIA-6098 fix `authId` multiple instances

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.25'
+    ext.kotlin_version = "2.1.21"
 
     repositories {
         google()
@@ -23,7 +23,7 @@ plugins {
     id 'io.github.dryrum.replace-in-file' version '0.7.0'
     id 'io.github.dryrum.git-utils' version '0.7.0'
     id 'io.github.dryrum.bump-version-code' version '0.7.0'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '2.0.21'
+    id 'org.jetbrains.kotlin.plugin.serialization' version "2.1.21"
 }
 
 allprojects {

--- a/cmplibrary/build.gradle.kts
+++ b/cmplibrary/build.gradle.kts
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-    implementation("com.sourcepoint:core:0.1.11")
+    implementation("com.sourcepoint:core:0.1.12-beta-3")
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLib.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/SpConsentLib.kt
@@ -28,6 +28,7 @@ interface SpConsentLib {
      */
     fun loadMessage(cmpViewId: Int)
 
+    // TODO: remove authId from loadMessages and move it to SpConfig in the next major release
     /**
      * Load the First Layer Message (FLM)
      * @param authId is used to get an already saved consent

--- a/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/legacy/TransferFromNativeSDK.kt
+++ b/cmplibrary/src/main/java/com/sourcepoint/cmplibrary/legacy/TransferFromNativeSDK.kt
@@ -24,16 +24,12 @@ fun migrateLegacyToNewState(
     propertyId: Int
 ): State? {
     if (preferences.contains(LegacyLocalState.PREFS_KEY)) {
-        try {
-            val newState = LegacyState(preferences).toState(accountId, propertyId)
-            removeLegacyData(preferences)
-            return newState
-        } catch (_: Exception) {
-            return null
-        }
-    } else {
-        return null
+        val legacyState = LegacyState(preferences)
+        val newState = legacyState.toState(accountId, propertyId)
+        removeLegacyData(preferences)
+        return newState
     }
+    return null
 }
 
 fun removeLegacyData(preferences: SharedPreferences) {
@@ -83,19 +79,19 @@ data class LegacyState(
     }
 
     constructor(sharedPrefs: SharedPreferences) : this(
-        gdpr = sharedPrefs.getString(GDPRLegacyConsent.PREFS_KEY, null)?.let { json.decodeFromString(it) },
-        ccpa = sharedPrefs.getString(CCPALegacyConsent.PREFS_KEY, null)?.let { json.decodeFromString(it) },
-        usnat = sharedPrefs.getString(USNatLegacyConsent.PREFS_KEY, null)?.let { json.decodeFromString(it) },
-        metaData = sharedPrefs.getString(LegacyMetaData.PREFS_KEY, null)?.let { json.decodeFromString(it) },
         authId = sharedPrefs.getString(AUTH_ID_PREFS_KEY, null),
+        gdpr = sharedPrefs.getString(GDPRLegacyConsent.PREFS_KEY, null)?.let { decodeWithLogging(it, "GDPRLegacyConsent") },
+        ccpa = sharedPrefs.getString(CCPALegacyConsent.PREFS_KEY, null)?.let { decodeWithLogging(it, "CCPALegacyConsent") },
+        usnat = sharedPrefs.getString(USNatLegacyConsent.PREFS_KEY, null)?.let { decodeWithLogging(it, "USNatLegacyConsent") },
+        metaData = sharedPrefs.getString(LegacyMetaData.PREFS_KEY, null)?.let { decodeWithLogging(it, "LegacyMetaData") },
         gdprSampled = sharedPrefs.getBoolean(LegacyGDPRSampled.PREFS_KEY, false),
         usnatSampled = sharedPrefs.getBoolean(LegacyUSNATSampled.PREFS_KEY, false),
         ccpaSampled = sharedPrefs.getBoolean(LegacyCCPASampled.PREFS_KEY, false),
         gdprChildPmId = sharedPrefs.getString(LegacyGDPRChildPmId.PREFS_KEY, null),
         ccpaChildPmId = sharedPrefs.getString(LegacyCCPAChildPmId.PREFS_KEY, null),
         usnatChildPmId = sharedPrefs.getString(LegacyUSNATChildPmId.PREFS_KEY, null),
-        localState = sharedPrefs.getString(LegacyLocalState.PREFS_KEY, null)?.let { json.decodeFromString(it) },
-        nonKeyedLocalState = sharedPrefs.getString(LegacyNonKeyedLocalState.PREFS_KEY, null)?.let { json.decodeFromString(it) }
+        localState = sharedPrefs.getString(LegacyLocalState.PREFS_KEY, null)?.let { decodeWithLogging(it, "LegacyLocalState") },
+        nonKeyedLocalState = sharedPrefs.getString(LegacyNonKeyedLocalState.PREFS_KEY, null)?.let { decodeWithLogging(it, "LegacyNonKeyedLocalState") }
     )
 
     fun toState(accountId: Int, propertyId: Int) = State(

--- a/integration_tests/src/androidTest/java/com/sourcepoint/cmplibrary/legacy/LegacyStateTest.kt
+++ b/integration_tests/src/androidTest/java/com/sourcepoint/cmplibrary/legacy/LegacyStateTest.kt
@@ -108,7 +108,13 @@ class LegacyStateTest {
         loadLegacySharedPrefs(preferences, faultyLegacySharedPrefsXML)
         migrateLegacyToNewState(preferences, accountId, propertyId).assertNotNull()
         preferences.getString(LegacyLocalState.PREFS_KEY, null).assertNull()
+    }
+
+    @Test
+    fun testMigratingLegacyStateReturnsNullIfLegacyStateIsNotPresent() {
+        loadLegacySharedPrefs(preferences, sharedPrefsWithoutLegacyState)
         migrateLegacyToNewState(preferences, accountId, propertyId).assertNull()
-        preferences.getString(LegacyLocalState.PREFS_KEY, null).assertNotNull()
+        preferences.getString(LegacyLocalState.PREFS_KEY, null).assertNull()
+        preferences.getString("foo", null).assertEquals("bar")
     }
 }

--- a/integration_tests/src/androidTest/java/com/sourcepoint/cmplibrary/legacy/LegacyStateTest.kt
+++ b/integration_tests/src/androidTest/java/com/sourcepoint/cmplibrary/legacy/LegacyStateTest.kt
@@ -106,6 +106,8 @@ class LegacyStateTest {
     @Test
     fun testMigratingLegacyStateDoesntThrowEvenWhenInvalid() {
         loadLegacySharedPrefs(preferences, faultyLegacySharedPrefsXML)
+        migrateLegacyToNewState(preferences, accountId, propertyId).assertNotNull()
+        preferences.getString(LegacyLocalState.PREFS_KEY, null).assertNull()
         migrateLegacyToNewState(preferences, accountId, propertyId).assertNull()
         preferences.getString(LegacyLocalState.PREFS_KEY, null).assertNotNull()
     }

--- a/integration_tests/src/androidTest/java/com/sourcepoint/cmplibrary/legacy/SharedPrefsImporter.kt
+++ b/integration_tests/src/androidTest/java/com/sourcepoint/cmplibrary/legacy/SharedPrefsImporter.kt
@@ -60,3 +60,9 @@ const val faultyLegacySharedPrefsXML = """<?xml version='1.0' encoding='utf-8' s
     <string name="sp.key.messages.v7.local.state">{}</string>
 </map>
 """
+
+const val sharedPrefsWithoutLegacyState = """<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<map>
+    <string name="foo">bar</string>
+</map>
+"""

--- a/samples/metaapp/build.gradle.kts
+++ b/samples/metaapp/build.gradle.kts
@@ -72,11 +72,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    tasks {
-        withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-            kotlinOptions.jvmTarget = "11"
-        }
-    }
 
     testOptions {
         // JSONObject return null during unit tests
@@ -88,10 +83,6 @@ android {
     lint {
         // https://stackoverflow.com/questions/44751469/kotlin-extension-functions-suddenly-require-api-level-24/44752239
         abortOnError = false
-    }
-
-    kotlinOptions {
-        jvmTarget = "11"
     }
 }
 


### PR DESCRIPTION
Authenticated consent seems to be working only on instances of the SDK that have had `loadMessages` called with `authId`. 

If another instance of the SDK is then initialized, that instance of the SDK won't have the value stored for `authId` and consent actions (from the PM for example), won't be stored for that `authId`. 

This PR and https://github.com/SourcePointUSA/mobile-core/pull/78 fixes this issue.